### PR TITLE
Adding stellar spectrum + batman transits to simulated.py

### DIFF
--- a/chromatic/imports.py
+++ b/chromatic/imports.py
@@ -15,5 +15,8 @@ from matplotlib.gridspec import GridSpec, GridSpecFromSubplotSpec
 
 from scipy.interpolate import interp1d
 
+# For modelling transits.
+import batman
+
 # define a driectory where we can put any necessary data files
 data_directory = pkg_resources.resource_filename("chromatic", "data")

--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -301,6 +301,7 @@ class Rainbow(Talker):
     def imshow(
         self,
         ax=None,
+        quantity='flux',
         w_unit="micron",
         t_unit="hour",
         aspect="auto",
@@ -347,7 +348,7 @@ class Rainbow(Talker):
 
         with quantity_support():
             plt.sca(ax)
-            plt.imshow(self.flux, extent=extent, aspect=aspect, origin=origin, **kw)
+            plt.imshow(self.fluxlike[quantity], extent=extent, aspect=aspect, origin=origin, **kw)
             if self.wscale == "linear":
                 plt.ylabel(f"Wavelength ({w_unit.to_string('latex_inline')})")
             elif self.wscale == "log":

--- a/chromatic/rainbows/simulated.py
+++ b/chromatic/rainbows/simulated.py
@@ -299,7 +299,10 @@ class SimulatedRainbow(Rainbow):
 
         for i in range(len(self.wavelike["wavelength"])):
             params.rp = rprs[i]
-            m = batman.TransitModel(params, self.timelike["time"])
+            try:
+                m
+            except NameError:
+                m = batman.TransitModel(params, self.timelike["time"].to('day').value)
             planet_flux[i] = m.light_curve(params)
 
         self.fluxlike["model"] = self.fluxlike["model"] * planet_flux

--- a/chromatic/rainbows/simulated.py
+++ b/chromatic/rainbows/simulated.py
@@ -12,6 +12,10 @@ class SimulatedRainbow(Rainbow):
         R=20,
         dw=None,
         wavelength=None,
+        star_flux=None,
+        planet=False,
+        planet_params={},
+        planet_radius=0.1,
     ):
         """
         Create a simulated rainbow object.
@@ -56,6 +60,19 @@ class SimulatedRainbow(Rainbow):
             1) wavelength
             2) wlim + dw
             3) wlim + R
+
+        star_flux : numpy 1D array
+            An array of fluxes corresponding to the supplied wavelengths.
+            If left blank, the code assumes a normalized flux of
+            flux(wavelength) = 1 for all wavelengths.
+        planet : boolean
+            Set to True to add a transiting planet.
+        planet_params: Dictionary
+            Stores planetary parameters to model, read description for
+            Rainbow.add_planet transit() for more details.
+        planet_radius: float or 1D numpy array
+            Planet Radius/Stellar Radius of planet.  Use 1D if wavelength-
+            dependent.  Must be same shape as wavelength array.
         """
         Rainbow.__init__(self)
 
@@ -65,12 +82,30 @@ class SimulatedRainbow(Rainbow):
         # set up the time grid
         self._setup_fake_time_grid(tlim=tlim, dt=dt, time=time)
 
-        # set up the uncertainty array
-        self.fluxlike["uncertainty"] = np.ones(self.shape) / signal_to_noise
+        # Save SNR.
         self.signal_to_noise = signal_to_noise
 
-        # set up the simulated flux array
-        self.fluxlike["model"] = np.ones(self.shape)
+        # If the flux of the star is not given,
+        # assume a continuum-normlized flux where fx=1 at all wavelengths.
+        if star_flux is None:
+            self.fluxlike["model"] = np.ones(self.shape)
+
+        # If the flux vs wavelength of the star is supplied,
+        # include it in the model.
+        else:
+            # Check to make sure the flux and wavelengths
+            # have the same shape.
+            if len(star_flux) == len(self.wavelike["wavelength"]):
+                self.fluxlike["model"] = np.transpose([star_flux] * self.shape[1])
+
+        # Include a planet, if desired.
+        if planet == True:
+            self.add_planet_transit(
+                planet_params=planet_params, planet_radius=planet_radius
+            )
+
+        # Set uncertainty.
+        self.fluxlike["uncertainty"] = self.fluxlike["model"] / signal_to_noise
         self.fluxlike["flux"] = np.random.normal(
             self.fluxlike["model"], self.fluxlike["uncertainty"]
         )
@@ -113,11 +148,7 @@ class SimulatedRainbow(Rainbow):
         # TODO, make this match up better with astropy time
 
     def _setup_fake_wavelength_grid(
-        self,
-        wlim=[0.5 * u.micron, 5 * u.micron],
-        R=100,
-        dw=None,
-        wavelength=None,
+        self, wlim=[0.5 * u.micron, 5 * u.micron], R=100, dw=None, wavelength=None
     ):
         """
         Create a fake wavelength grid.
@@ -182,3 +213,99 @@ class SimulatedRainbow(Rainbow):
 
         # this should break if the units aren't length
         w_unit.to("m")
+
+    def add_planet_transit(self, planet_params={}, planet_radius=0.1):
+
+        """
+        Simulate a wavelength-dependent planetary transit using
+        batman.
+
+        TODO:
+        Simpler way to implement radius input
+        Make it faster
+        Check and make sure things are correct in terms of units.
+        implement astropy units?
+
+        Parameters
+        ----------
+
+        planet_params : Dictionary
+            Values for planetary parameters for use in batman modelling.
+            Any values not supplied will be set to defaults:
+                "t0" = time of inferior conjunction (default 0)
+                "per" = orbital period (hours) (detault 1)
+                "a" = semi-major axis (units of stellar radii) (default 15)
+                "inc" = inclination (degrees) (default 90)
+                "ecc" = eccentricity (default 0)
+                "w" = longitude of periastron (degrees)(default 0)
+                "limb_dark" = limb-darkening model (default "nonlinear")
+                "u" = limb-darkening coefficients (default [0.5, 0.1, 0.1, -0.1])
+            example value: planet_params = {"a":12, "inc":87}
+
+        planet_radius = Two options:
+                1D array with same dimensions as wavelength array,
+                    each value corresponds to planet radius/stellar radius at that
+                    wavelength.
+                float representing Rp/Rstar if the radius is not wavelength-dependent.
+            example value: planet_radius = 0.01,
+
+        """
+
+        # First, make sure planet_radius has the right dimension.
+        if type(planet_radius) != float and len(planet_radius) != len(
+            self.wavelike["wavelength"]
+        ):
+            print(
+                "Invalid planet radius array: must be float or have shape "
+                + str(np.shape(self.wavelike["wavelength"]))
+            )
+
+        # Defaults for planet simulation.
+        defaults = {
+            "t0": 0,
+            "per": 1,
+            "a": 15,
+            "inc": 90,
+            "ecc": 0,
+            "w": 0,
+            "limb_dark": "nonlinear",
+            "u": [0.5, 0.1, 0.1, -0.1],
+        }
+
+        # Read in planet parameters.
+        for i in range(len(planet_params.keys())):
+            key = list(planet_params.keys())[i]
+            if key in list(defaults.keys()):
+                defaults[key] = planet_params[key]
+            else:
+                print("Warning: " + str(key) + " not a valid parameter")
+
+        # Initialize batman model.
+        params = batman.TransitParams()
+        params.t0 = defaults["t0"]
+        params.per = defaults["per"]
+        params.a = defaults["a"]
+        params.inc = defaults["inc"]
+        params.ecc = defaults["ecc"]
+        params.w = defaults["w"]
+        params.limb_dark = defaults["limb_dark"]
+        params.u = defaults["u"]
+
+        # Read in planetary radius.
+        if type(planet_radius) == float:
+            rprs = np.zeros(len(self.wavelike["wavelength"])) + planet_radius
+        else:
+            rprs = planet_radius
+            # Account for how rainbow indexes wavelengths.
+            rprs = np.flip(rprs)
+
+        planet_flux = np.zeros(
+            (len(self.wavelike["wavelength"]), len(self.timelike["time"]))
+        )
+
+        for i in range(len(self.wavelike["wavelength"])):
+            params.rp = rprs[i]
+            m = batman.TransitModel(params, self.timelike["time"])
+            planet_flux[i] = m.light_curve(params)
+
+        self.fluxlike["model"] = self.fluxlike["model"] * planet_flux

--- a/chromatic/rainbows/simulated.py
+++ b/chromatic/rainbows/simulated.py
@@ -13,9 +13,6 @@ class SimulatedRainbow(Rainbow):
         dw=None,
         wavelength=None,
         star_flux=None,
-        planet=False,
-        planet_params={},
-        planet_radius=0.1,
     ):
         """
         Create a simulated rainbow object.
@@ -30,7 +27,7 @@ class SimulatedRainbow(Rainbow):
             wavelength-time data point will be 1%.
 
         tlim : list or array of astropy.units.Quantity
-            The [min, max] times for creating the time grid.
+            The pip install -e '.[develop]'[min, max] times for creating the time grid.
             These should have astropy units of time.
         dt : astropy.units.Quantity
             The d(time) bin size for creating a grid
@@ -97,12 +94,6 @@ class SimulatedRainbow(Rainbow):
             # have the same shape.
             if len(star_flux) == len(self.wavelike["wavelength"]):
                 self.fluxlike["model"] = np.transpose([star_flux] * self.shape[1])
-
-        # Include a planet, if desired.
-        if planet == True:
-            self.add_planet_transit(
-                planet_params=planet_params, planet_radius=planet_radius
-            )
 
         # Set uncertainty.
         self.fluxlike["uncertainty"] = self.fluxlike["model"] / signal_to_noise
@@ -214,7 +205,7 @@ class SimulatedRainbow(Rainbow):
         # this should break if the units aren't length
         w_unit.to("m")
 
-    def add_planet_transit(self, planet_params={}, planet_radius=0.1):
+    def inject_transit(self, planet_params={}, planet_radius=0.1):
 
         """
         Simulate a wavelength-dependent planetary transit using
@@ -225,6 +216,9 @@ class SimulatedRainbow(Rainbow):
         Make it faster
         Check and make sure things are correct in terms of units.
         implement astropy units?
+        handle errors differently?
+        make this return a rainbow() object with the planet added instead
+        of modifying in place?
 
         Parameters
         ----------
@@ -309,3 +303,6 @@ class SimulatedRainbow(Rainbow):
             planet_flux[i] = m.light_curve(params)
 
         self.fluxlike["model"] = self.fluxlike["model"] * planet_flux
+        self.fluxlike["flux"] = np.random.normal(
+            self.fluxlike["model"], self.fluxlike["uncertainty"]
+        )

--- a/chromatic/rainbows/simulated.py
+++ b/chromatic/rainbows/simulated.py
@@ -226,8 +226,8 @@ class SimulatedRainbow(Rainbow):
         planet_params : Dictionary
             Values for planetary parameters for use in batman modelling.
             Any values not supplied will be set to defaults:
-                "t0" = time of inferior conjunction (default 0)
-                "per" = orbital period (hours) (detault 1)
+                "t0" = time of inferior conjunction (days) (default 0)
+                "per" = orbital period (days) (detault 1)
                 "a" = semi-major axis (units of stellar radii) (default 15)
                 "inc" = inclination (degrees) (default 90)
                 "ecc" = eccentricity (default 0)
@@ -302,7 +302,7 @@ class SimulatedRainbow(Rainbow):
             try:
                 m
             except NameError:
-                m = batman.TransitModel(params, self.timelike["time"].to('day').value)
+                m = batman.TransitModel(params, self.timelike["time"].to("day").value)
             planet_flux[i] = m.light_curve(params)
 
         self.fluxlike["model"] = self.fluxlike["model"] * planet_flux

--- a/chromatic/tests/test_simulated_rainbow.py
+++ b/chromatic/tests/test_simulated_rainbow.py
@@ -11,3 +11,13 @@ def test_simulated_rainbow():
     e = SimulatedRainbow(wlim=[0.1, 1] * u.micron, dw=1 * u.nm)
     assert e.wscale == "linear"
     f = SimulatedRainbow(wavelength=np.logspace(0, 1) * u.micron)
+    g = SimulatedRainbow(
+        wavelength=np.logspace(0, 1) * u.micron, star_flux=np.logspace(0, 1)
+    )
+    h = SimulatedRainbow(planet=True)
+    i = SimulatedRainbow(planet=True, planet_params={"per": 0.1})
+    j = SimulatedRainbow(
+        wavelength=np.logspace(0, 1) * u.micron,
+        planet=True,
+        planet_radius=np.zeros(50) + 0.1,
+    )

--- a/chromatic/tests/test_simulated_rainbow.py
+++ b/chromatic/tests/test_simulated_rainbow.py
@@ -14,10 +14,6 @@ def test_simulated_rainbow():
     g = SimulatedRainbow(
         wavelength=np.logspace(0, 1) * u.micron, star_flux=np.logspace(0, 1)
     )
-    h = SimulatedRainbow(planet=True)
-    i = SimulatedRainbow(planet=True, planet_params={"per": 0.1})
-    j = SimulatedRainbow(
-        wavelength=np.logspace(0, 1) * u.micron,
-        planet=True,
-        planet_radius=np.zeros(50) + 0.1,
-    )
+    h = SimulatedRainbow(wavelength=np.logspace(0, 1) * u.micron)
+    h.inject_transit(planet_params={"per": 0.1})
+    h.inject_transit(planet_radius=np.zeros(50) + 0.1)

--- a/chromatic/tests/test_simulated_rainbow.py
+++ b/chromatic/tests/test_simulated_rainbow.py
@@ -1,7 +1,7 @@
 from ..rainbows import *
 
 
-def test_simulated_rainbow():
+def test_simulated_basics():
 
     a = SimulatedRainbow()
     b = SimulatedRainbow(tlim=[-1, 1] * u.hour, dt=1 * u.minute)
@@ -11,9 +11,18 @@ def test_simulated_rainbow():
     e = SimulatedRainbow(wlim=[0.1, 1] * u.micron, dw=1 * u.nm)
     assert e.wscale == "linear"
     f = SimulatedRainbow(wavelength=np.logspace(0, 1) * u.micron)
+
+def test_star_flux():
     g = SimulatedRainbow(
         wavelength=np.logspace(0, 1) * u.micron, star_flux=np.logspace(0, 1)
     )
+
+def test_inject_transit():
     h = SimulatedRainbow(wavelength=np.logspace(0, 1) * u.micron)
     h.inject_transit(planet_params={"per": 0.1})
     h.inject_transit(planet_radius=np.zeros(50) + 0.1)
+
+    i  = SimulatedRainbow(signal_to_noise=1000, dt=2*u.minute)
+    i.inject_transit(planet_params=dict(per=3),
+                 planet_radius=np.random.normal(0.1, 0.01, i.nwave))
+    i.imshow();

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup(
         "matplotlib>=3.0",
         "astropy>=4.0",
         "tqdm",
+        "batman-package"
     ],
     # what version of Python is required?
     python_requires=">=3.6",  # f-strings are introduced in 3.6!


### PR DESCRIPTION
Additions:

-in simulated.py:
Ability to input a stellar flux star_flux into SimulatedRainbow class (assumed static with time).  
function SimulatedRainbow.inject_transit(), which takes in a dictionary of planetary parameters and an array of R_planet/R_star with wavelength (or just a float if it's constant with wavelength).  This modifies the object in-place and can be called multiple times with different planetary parameters if desired.  (potential future work: make it return a new Rainbow() with the planet added)


-batman import to imports.py
-some new tests of these functionality in test_simulated_rainbow.py