### PR TITLE
switch `.wscale` to `.metadata['wscale']`; add `_guess_wscale`

### DIFF
--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -7,6 +7,7 @@ class Rainbow(Talker):
     """
     Rainbow objects represent the flux of an object as a function of both wavelength and time.
     """
+    _core_dictionaries = ['fluxlike', 'timelike', 'wavelike', 'metadata']
 
     def __init__(self, wavelength=None, time=None, flux=None, uncertainty=None, **kw):
         """
@@ -22,8 +23,10 @@ class Rainbow(Talker):
             A 2D array of flux values.
         uncertainty : np.array
             A 2D array of uncertainties, associated with the flux.
-
         """
+
+        # metadata are arbitrary types of information we need
+        self.metadata = {}
 
         # wavelike quanities are 1D arrays with nwave elements
         self.wavelike = {}
@@ -38,35 +41,79 @@ class Rainbow(Talker):
         self.fluxlike["flux"] = flux
         self.fluxlike["uncertainty"] = uncertainty
 
+        self._guess_wscale()
+
+    def _guess_wscale(self):
+        '''
+        Try to guess the wscale from the wavelengths.
+        '''
+
+        # give up if there's no wavelength array
+        if self.wavelength is None:
+            return '?'
+
+        # calculate difference arrays
+        w = self.wavelength.value
+        dw = np.diff(w)
+        dlogw = np.diff(np.log(w))
+
+        # test the three options
+        if np.all(dw == dw[0]):
+            self.metadata['wscale'] = 'linear'
+        elif np.all(dlogw == dlogw[0]):
+            self.metadata['wscale'] = 'log'
+        else:
+            self.metadata['wscale'] = '?'
+
+    def __getattr__(self, key):
+        '''
+        If an attribute/method isn't explicitly defined,
+        try to pull it from one of the core dictionaries.
+
+        Let's say you want to get the 2D uncertainty array
+        but don't want to type `self.fluxlike['uncertainty']`.
+        You could instead type `self.uncertainty`, and this
+        would try to search through the four standard
+        dictionaries to pull out the first `uncertainty`
+        it finds.
+
+        Parameters
+        ----------
+        key : str
+            The attribute we're trying to get.
+        '''
+        if key not in self._core_dictionaries:
+            for dictionary_name in self._core_dictionaries:
+                try:
+                    return self.__dict__[dictionary_name][key]
+                except KeyError:
+                    pass
+
+    # TODO - what should we do with __setattr__?
+    #   actually allow to reset things in metadata?
+    #   give a warning that you try to set something you shouldn't?
+    #   if things have the right size, just organize them 
+
     @property
     def _nametag(self):
+        '''
+        This short phrase will preface everything
+        said with `self.speak()`.
+        '''
         return f'🌈({self.nwave}w, {self.ntime}t)'
-    @property
-    def wavelength(self):
-        return self.wavelike["wavelength"]
-
-    # @wavelength.setter
-    # def wavelength(self, value):
-    #    self.wavelike['wavelength'] = value
-
-    @property
-    def time(self):
-        return self.timelike["time"]
-
-    @property
-    def flux(self):
-        return self.fluxlike["flux"]
-
-    @property
-    def uncertainty(self):
-        return self.fluxlike["uncertainty"]
 
     @property
     def shape(self):
+        '''
+        The shape of the flux array (nwave, ntime)
+        '''
         return (self.nwave, self.ntime)
 
     @property
     def nwave(self):
+        '''
+        The number of wavelengths
+        '''
         if self.wavelength is None:
             return 0
         else:
@@ -74,6 +121,9 @@ class Rainbow(Talker):
 
     @property
     def ntime(self):
+        '''
+        The number of times
+        '''
         if self.time is None:
             return 0
         else:
@@ -81,9 +131,15 @@ class Rainbow(Talker):
 
     @property
     def nflux(self):
+        '''
+        The number of fluxes
+        '''
         return np.prod(self.shape)
 
     def __repr__(self):
+        '''
+        How should this object be represented as a string?
+        '''
         n = self.__class__.__name__.replace('Rainbow', '🌈')
         return f"<{n}({self.nwave}w, {self.ntime}t)>"
 
@@ -165,7 +221,7 @@ class Rainbow(Talker):
 
         # populate the wavelength information
         new.wavelike = {**self.wavelike}
-        new.wscale = self.wscale
+        new.metadata['wscale'] = self.wscale
 
         # bin the time-like variables
         # TODO (add more careful treatment of uncertainty + DQ)
@@ -297,7 +353,7 @@ class Rainbow(Talker):
                 else:
                     new.fluxlike[k][:, t] = bv
             #self.speak(f"  new shape is {np.shape(new.fluxlike[k])}")
-        new.wscale = wscale
+        new.metadata['wscale'] = wscale
         return new
 
     def imshow(

--- a/chromatic/rainbows/simulated.py
+++ b/chromatic/rainbows/simulated.py
@@ -80,7 +80,7 @@ class SimulatedRainbow(Rainbow):
         self._setup_fake_time_grid(tlim=tlim, dt=dt, time=time)
 
         # Save SNR.
-        self.signal_to_noise = signal_to_noise
+        self.metadata['signal_to_noise'] = signal_to_noise
 
         # If the flux of the star is not given,
         # assume a continuum-normlized flux where fx=1 at all wavelengths.
@@ -178,8 +178,8 @@ class SimulatedRainbow(Rainbow):
 
             w_unit = wlim[0].unit
             if dw is None:
-                self.R = R
-                self.wscale = "log"
+                self.metadata['R'] = R
+                self.metadata['wscale'] = "log"
 
                 logw_min = np.log(wlim[0] / w_unit)
                 logw_max = np.log(wlim[1] / w_unit)
@@ -187,8 +187,8 @@ class SimulatedRainbow(Rainbow):
                 wavelength = np.exp(logw) * w_unit
 
             elif dw is not None:
-                self.dw = dw
-                self.wscale = "linear"
+                self.metadata['dw'] = dw
+                self.metadata['wscale'] = "linear"
                 wavelength = (
                     np.arange(wlim[0] / w_unit, wlim[1] / w_unit, self.dw / w_unit)
                     * w_unit
@@ -197,7 +197,7 @@ class SimulatedRainbow(Rainbow):
         # or just make sure the wavelength grid has units
         elif wavelength is not None:
             w_unit = wavelength.unit
-            self.wscale = "?"
+            self.metadata['wscale'] = "?"
 
         # make sure the wavelength array has units
         self.wavelike["wavelength"] = u.Quantity(wavelength)

--- a/chromatic/tests/test_visualizations.py
+++ b/chromatic/tests/test_visualizations.py
@@ -8,8 +8,12 @@ def test_imshow():
     plt.figure()
     SimulatedRainbow(dw=0.2 * u.micron).imshow()
 
+    plt.figure()
+    Rainbow(wavelength=np.arange(1,5)*u.micron,
+            time=np.arange(1,6)*u.hour,
+            flux=np.ones((4,5))).imshow()
+
     fi, ax = plt.subplots(2, 1, sharex=True)
     SimulatedRainbow(R=10).imshow(w_unit="nm", ax=ax[0])
     SimulatedRainbow(dw=0.2 * u.micron).imshow(ax=ax[1], w_unit="nm")
-
     plt.savefig(os.path.join(test_directory, 'imshow-demonstration.pdf'))

--- a/docs/basics.ipynb
+++ b/docs/basics.ipynb
@@ -155,10 +155,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you want to look closely at what's happening behind the scenes, these properties are being pulled from three core dictionaries. These are designed to store quantities that have dimensions like either `wavelength`, `time`, or `flux`:\n",
+    "If you want to look closely at what's happening behind the scenes, these properties are being pulled from some core dictionaries. These are designed to store quantities that have dimensions like either `wavelength`, `time`, or `flux`:\n",
     "- `.wavelike[...]` contains everything that has the same dimensions as `wavelength`. This dictionary will contain at least a `'wavelength'` key, with the actual wavelengths themselves. It might *also* contain information like the average spectrum of the star, the average S/N at each wavelength, the number of original detector pixels that wound up in this particular wavelength bin, and/or a mask of what wavelengths should be considered good or bad (no matter the time point). \n",
     "- `.timelike[...]` contains everything that has the same dimensons as `time`. This dictionary will contain at least a `'time'` key, with the actual times themselves. It might *also* contain information like a broadband light curve of the transit, the x or y position of the spectrum on the detector, the temperature of the detector, and/or a mask of what times should be considered good or bad (no matter the wavelength).\n",
-    "- `.fluxlike[...]` contains everything that has the same dimensons as `flux`. This dictionary will contain at least a `'flux'` key, with the actual fluxes themselves. It should also contain an `'uncertainty'` keyword with the uncertainties associated with those fluxes (or maybe `None`). It might *also* contain information about other quantities that depend on both time and wavelength, such as the centroid of the spectral trace, the maximum fraction of saturation, and/or a mask of what individual points should be considered good or bad."
+    "- `.fluxlike[...]` contains everything that has the same dimensons as `flux`. This dictionary will contain at least a `'flux'` key, with the actual fluxes themselves. It should also contain an `'uncertainty'` keyword with the uncertainties associated with those fluxes (or maybe `None`). It might *also* contain information about other quantities that depend on both time and wavelength, such as the centroid of the spectral trace, the maximum fraction of saturation, and/or a mask of what individual points should be considered good or bad.\n",
+    "\n",
+    "There is one more core dictionary:\n",
+    "- `.metadata` contains general information that might be useful to hang onto, to pass along to another derived object, or to save out to a file"
    ]
   },
   {
@@ -189,10 +192,19 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.metadata.keys()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `.wavelength`, `.time`, `.flux` properties pull directly from these dictionaries. "
+    "When you call something like `.wavelength`, `.time`, `.flux`, they are being pulled directly from these dictionaries. This means you generally can't do something like `r.wavelength = 5`; if you want to (very carefully and with an understanding you might break things) change the values of something being pulled from a core dictionary, you need to explicitly say `r.wavelike['wavelength'] = 5`."
    ]
   }
  ],


### PR DESCRIPTION
Three changes:
1. Solve #2 , to make sure that `wscale` gets defined even for a basic `Rainbow` class. 
2. Switch to storing important metadata that we might want to pass onward to other derived objects, or ultimately save into a file, into a fourth core dictionary called `.metadata`. This includes `.wscale`, which is now stored as `.metadata['wscale']`. 
3. Add a `__getattr__` that will automatically search `fluxlike`, `timelike`, `wavelike`, `metadata` (in that order) for anything requested as `.x`. This replaces the previous properties for `.wavelength`, `.time`, and `.flux`. 

@madisontbrady , I think this solves your #2? I added a test of creating a simple `Rainbow` from scratch, and I was able to `.imshow` it without issue.
