### PR TITLE
Add wavelength-dependent limb-darkening to inject_transit

### DIFF
--- a/chromatic.egg-info/requires.txt
+++ b/chromatic.egg-info/requires.txt
@@ -3,7 +3,7 @@ scipy
 matplotlib>=3.0
 astropy>=4.0
 tqdm
-copy
+batman-package
 
 [cartoons]
 rainbow-connection>=0.0.7

--- a/chromatic/rainbows/simulated.py
+++ b/chromatic/rainbows/simulated.py
@@ -180,7 +180,7 @@ class SimulatedRainbow(Rainbow):
             w_unit = wlim[0].unit
             if dw is None:
                 self.metadata["R"] = R
-                #self.metadata["wscale"] = "log"
+                # self.metadata["wscale"] = "log"
 
                 logw_min = np.log(wlim[0] / w_unit)
                 logw_max = np.log(wlim[1] / w_unit)
@@ -189,7 +189,7 @@ class SimulatedRainbow(Rainbow):
 
             elif dw is not None:
                 self.metadata["dw"] = dw
-                #self.metadata["wscale"] = "linear"
+                # self.metadata["wscale"] = "linear"
                 wavelength = (
                     np.arange(wlim[0] / w_unit, wlim[1] / w_unit, self.dw / w_unit)
                     * w_unit
@@ -212,15 +212,6 @@ class SimulatedRainbow(Rainbow):
         Simulate a wavelength-dependent planetary transit using
         batman.
 
-        TODO:
-        Simpler way to implement radius input
-        Make it faster
-        Check and make sure things are correct in terms of units.
-        implement astropy units?
-        handle errors differently?
-        make this return a rainbow() object with the planet added instead
-        of modifying in place?
-
         Parameters
         ----------
 
@@ -233,8 +224,22 @@ class SimulatedRainbow(Rainbow):
                 "inc" = inclination (degrees) (default 90)
                 "ecc" = eccentricity (default 0)
                 "w" = longitude of periastron (degrees)(default 0)
-                "limb_dark" = limb-darkening model (default "nonlinear")
+                "limb_dark" = limb-darkening model (default "nonlinear"), possible
+                    values described in more detail in batman documentation
                 "u" = limb-darkening coefficients (default [0.5, 0.1, 0.1, -0.1])
+                    Can take 3 forms:
+                    -A single value (if limb-darkening law requires only one value)
+                    -A 1D list/array of coefficients corresponding to the limb-darkening
+                    law
+                    -A 2D array of the form (n_wavelengths, n_coefficients) where
+                    each row is the set of limb-darkening coefficients corresponding
+                    to a single wavelength
+
+                    Note that this currently does not calculate the appropriate
+                    coefficient vs wavelength variations itself- there exist codes
+                    (such as hpparvi/PyLDTk and nespinoza/limb-darkening) which
+                    can be used for this.
+
             example value: planet_params = {"a":12, "inc":87}
 
         planet_radius = Two options:
@@ -247,9 +252,7 @@ class SimulatedRainbow(Rainbow):
         """
 
         # First, make sure planet_radius has the right dimension.
-        if type(planet_radius) != float and len(planet_radius) != len(
-            self.wavelike["wavelength"]
-        ):
+        if type(planet_radius) != float and len(planet_radius) != self.nwave:
             print(
                 "Invalid planet radius array: must be float or have shape "
                 + str(np.shape(self.wavelike["wavelength"]))
@@ -284,20 +287,34 @@ class SimulatedRainbow(Rainbow):
         params.ecc = defaults["ecc"]
         params.w = defaults["w"]
         params.limb_dark = defaults["limb_dark"]
-        params.u = defaults["u"]
+
+        # Deal with limb-darkening.
+        if len(np.shape(defaults["u"])) < 2:  # Coefficients constant with wavelength
+            u_arr = np.tile(defaults["u"], (self.nwave, 1))
+
+        elif (
+            len(np.shape(defaults["u"])) == 2
+        ):  # 2D array of coefficients, along wavelength axis
+            if np.shape(defaults["u"])[0] != self.nwave:
+                print("Shape of limb-darkening array does not match wavelengths.")
+                return
+            u_arr = defaults["u"]
+
+        else:
+            print("Invalid limb-darkening coefficient array.")
 
         # Read in planetary radius.
         if type(planet_radius) == float:
-            rprs = np.zeros(len(self.wavelike["wavelength"])) + planet_radius
+            rprs = np.zeros(self.nwave) + planet_radius
         else:
             rprs = planet_radius
 
-        planet_flux = np.zeros(
-            (len(self.wavelike["wavelength"]), len(self.timelike["time"]))
-        )
+        planet_flux = np.zeros((self.nwave, self.ntime))
 
-        for i in range(len(self.wavelike["wavelength"])):
+        for i in range(self.nwave):
             params.rp = rprs[i]
+            params.u = u_arr[i]
+            print(params.u)
             try:
                 m
             except NameError:

--- a/chromatic/tests/test_simulated_rainbow.py
+++ b/chromatic/tests/test_simulated_rainbow.py
@@ -26,15 +26,20 @@ def test_inject_transit():
     h.inject_transit(planet_radius=np.zeros(50) + 0.1)
 
     i = SimulatedRainbow(signal_to_noise=1000, dt=2 * u.minute)
-    fi, ax = plt.subplots(2, 1, sharex=True)
+    fi, ax = plt.subplots(3, 1, sharex=True, figsize=(8, 8))
     i.imshow(ax=ax[0], vmin=0.975, vmax=1.005)
     plt.xlabel("")
     i.inject_transit(
         planet_params=dict(per=3), planet_radius=np.random.normal(0.1, 0.01, i.nwave)
-    )
-    i.imshow(ax=ax[1], vmin=0.975, vmax=1.005)
+    ).imshow(ax=ax[1], vmin=0.975, vmax=1.005)
+    # test the limb darkening
+    i.inject_transit(
+        planet_params={
+            "per": 3,
+            "limb_dark": "quadratic",
+            "u": np.transpose(
+                [np.linspace(1.0, 0.0, i.nwave), np.linspace(0.5, 0.0, i.nwave)]
+            ),
+        },
+    ).imshow(ax=ax[2], vmin=0.975, vmax=1.005)
     plt.savefig(os.path.join(test_directory, "transit-injection-demonstration.pdf"))
-
-    h.inject_transit(
-        planet_params={"limb_dark": "quadratic", "u": np.ones((h.nwave, 2))}
-    )

--- a/chromatic/tests/test_simulated_rainbow.py
+++ b/chromatic/tests/test_simulated_rainbow.py
@@ -34,3 +34,7 @@ def test_inject_transit():
     )
     i.imshow(ax=ax[1], vmin=0.975, vmax=1.005)
     plt.savefig(os.path.join(test_directory, "transit-injection-demonstration.pdf"))
+
+    h.inject_transit(
+        planet_params={"limb_dark": "quadratic", "u": np.ones((h.nwave, 2))}
+    )

--- a/chromatic/viz.py
+++ b/chromatic/viz.py
@@ -60,7 +60,7 @@ def wavelength_plot(
         if np.any(np.isfinite(lc)):
             # normalize this light curve to one.
             cont_level = np.nanmedian(lc[cont_time == 1])
-            plot_flux = -i * step_size + lc #/ cont_level
+            plot_flux = -i * step_size + lc  # / cont_level
 
             color = (0, 0.3 - 0.3 * (i / nsteps), i / nsteps)
             assert (np.isfinite(plot_flux) == True).all()


### PR DESCRIPTION
Added functionality in simulated.py that allows for the user to input an array of limb-darkening parameters that vary with wavelength instead of just a constant array.  Should work with any limb-darkening model readable by `batman`.  Also added a test for this in test_simulated_rainbow.py.

So far, does not include a method that automatically calculates the wavelength-varying limb-darkening coefficients, as that seems to be a fairly complex procedure that is done by codes elsewhere.