### PR TITLE
fix `uncertainty` for `from_x1dints` reader

### DIFF
--- a/chromatic/rainbows/readers/stsci.py
+++ b/chromatic/rainbows/readers/stsci.py
@@ -164,6 +164,9 @@ def from_x1dints(rainbow, filepath):
         perhaps missing some segment files?
         """
         )
+
+    rainbow.fluxlike["uncertainty"] = rainbow.fluxlike["flux_error"]
+
     # try to guess wscale (and then kludge and call it linear)
     # rainbow._guess_wscale()
     # rainbow.metadata['wscale'] = 'linear' # TODO: fix this kludge

--- a/chromatic/version.py
+++ b/chromatic/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.8"
+__version__ = "0.0.9"
 
 
 def version():


### PR DESCRIPTION
tiny fix to link the `flux_error` column in `x1dints` files to the (necessary) `uncertainty` array