### PR TITLE
fix some eureka S3 reader problems; make imshow more flexible; fix a unit thing

### DIFF
--- a/chromatic/rainbows/readers/eureka.py
+++ b/chromatic/rainbows/readers/eureka.py
@@ -114,40 +114,36 @@ def eureadka_txt(filename):
     # load the data
     data = ascii.read(filename)
 
-    # pull out some variables
+    # figure out a time array
     for time_key in ["time", "bjdtdb"]:
         try:
             t = np.unique(data[time_key])
             break
         except KeyError:
             pass
-    w = np.unique(data["wave_1d"])
-
-    fluxes = np.ones(shape=(len(w), len(t)))
-    uncertainties = np.ones_like(fluxes)
-
-    i_time = np.arange(len(t))
-
-    for i_wavelength in tqdm(range(len(w))):
-
-        indices_for_this_wavelength = i_wavelength + i_time * len(w)
-        fluxes[i_wavelength, i_time] = data["optspec"][indices_for_this_wavelength]
-        uncertainties[i_wavelength, i_time] = data["opterr"][
-            indices_for_this_wavelength
-        ]
-
-    f = fluxes
-    e = uncertainties
-
     timelike = {}
-    timelike["time"] = t * u.day  # This is in MJD
+    timelike["time"] = t * u.day
 
+    # figure out a wavelength array
+    w = np.unique(data["wave_1d"])
     wavelike = {}
-    wavelike["wavelength"] = w * u.micron  # TODO: check wavelength units
+    wavelike["wavelength"] = w * u.micron
 
+    # populate the fluxlike quantities
     fluxlike = {}
-    fluxlike["flux"] = f
-    fluxlike["uncertainty"] = e
+    i_time = np.arange(len(t))
+    for k in data.colnames[2:]:
+        # if an array for this key doesn't exist, create it
+        if k not in fluxlike:
+            fluxlike[k] = np.zeros((len(w), len(t)))
+        # loop through wavelengths, populating all times for each
+        for i_wavelength in tqdm(range(len(w))):
+            # figure out all indices for this wavelengh
+            indices_for_this_wavelength = i_wavelength + i_time * len(w)
+            fluxlike[k][i_wavelength, i_time] = data[k][indices_for_this_wavelength]
+
+    fluxlike["flux"] = fluxlike["optspec"]
+    fluxlike["uncertainty"] = fluxlike["opterr"]
 
     return wavelike, timelike, fluxlike
 

--- a/chromatic/rainbows/readers/eureka.py
+++ b/chromatic/rainbows/readers/eureka.py
@@ -115,9 +115,9 @@ def eureadka_txt(filename):
     data = ascii.read(filename)
 
     # pull out some variables
-    for time_keys in ["time", "bjdtdb"]:
+    for time_key in ["time", "bjdtdb"]:
         try:
-            t = np.unique(data["bjdtdb"])
+            t = np.unique(data[time_key])
             break
         except KeyError:
             pass

--- a/chromatic/rainbows/visualizations.py
+++ b/chromatic/rainbows/visualizations.py
@@ -130,6 +130,8 @@ def imshow(
             (max(self.wavelength) / w_unit).decompose(),
             (min(self.wavelength) / w_unit).decompose(),
         ]
+        ylabel = f"Wavelength ({w_unit.to_string('latex_inline')})"
+
     elif self.wscale == "log":
         extent = [
             (min(self.time) / t_unit).decompose(),
@@ -137,8 +139,29 @@ def imshow(
             np.log10(max(self.wavelength) / w_unit),
             np.log10(min(self.wavelength) / w_unit),
         ]
+        ylabel = r"log$_{10}$" + f"[Wavelength/({w_unit.to_string('latex_inline')})]"
+
     else:
-        raise RuntimeError("Can't imshow without knowing wscale.")
+        message = f"""
+        The wavelength scale for this rainbow is {self.wscale}.
+        It's hard to imshow something with a wavelength axis
+        that isn't uniform in linear or logarithmic space, so
+        we're giving up and just using the wavelength index
+        as the wavelength axis.
+
+        If you want a real wavelength axis, one solution would
+        be to bin your wavelengths to a more uniform grid with
+        `rainbow.bin(R=...)` (for logarithmic wavelengths) or
+        `rainbow.bin(dw=...)` (for linear wavelengths)
+        """
+        warnings.warn(message)
+        extent = [
+            (min(self.time) / t_unit).decompose(),
+            (max(self.time) / t_unit).decompose(),
+            self.nwave,
+            0,
+        ]
+        ylabel = "Wavelength Index"
 
     with quantity_support():
         plt.sca(ax)
@@ -150,12 +173,7 @@ def imshow(
             interpolation="nearest",
             **kw,
         )
-        if self.wscale == "linear":
-            plt.ylabel(f"Wavelength ({w_unit.to_string('latex_inline')})")
-        elif self.wscale == "log":
-            plt.ylabel(
-                r"log$_{10}$" + f"[Wavelength/({w_unit.to_string('latex_inline')})]"
-            )
+        plt.ylabel(ylabel)
         plt.xlabel(f"Time ({t_unit.to_string('latex_inline')})")
         if colorbar:
             plt.colorbar(ax=ax, label=quantity)

--- a/chromatic/units.py
+++ b/chromatic/units.py
@@ -5,8 +5,14 @@ MJy_sr_sq = u.def_unit("(MJy/sr)^2", (u.MJy / u.sr) ** 2)
 u.add_enabled_units([MJy_sr, MJy_sr_sq])
 
 
-data_number = u.def_unit("DN")
 data_number_per_second = u.def_unit("DN/s")
-data_number_per_second_sq = u.def_unit("(DN/s)^2")
+data_number_per_second_sq = u.def_unit("(DN/s)^2", data_number_per_second ** 2)
+for kludge_DN_unit in [data_number_per_second, data_number_per_second_sq]:
+    try:
+        u.add_enabled_units([kludge_DN_unit])
+    except ValueError:
+        pass
 
-u.add_enabled_units([data_number, data_number_per_second, data_number_per_second_sq])
+# FIXME: some of these feel super kuldgy; how do we make this
+# interact more smoothly with units already defined in astropy
+# (for example, DN should work, but is always flaky for me...)

--- a/chromatic/version.py
+++ b/chromatic/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.15"
+__version__ = "0.0.16"
 
 
 def version():


### PR DESCRIPTION
For reading in S3 files...
- Fix a problem with what the time column should be called.
- Read in all fluxlike quantities, and then assign `optspec` and `opterr` to be the `flux` and `uncertainty`.

For imshow...
- Relax the overly strict behavior that "if you don't have an easy wavelength scale we won't make you an imshow". Now, it just plots wavelength index if it needs a guess. 

For units...
- Fix a "DN" unit conflict problem. I still don't quite understand why I can only sometimes access the astropy `DN` unit, but I'm not going to worry about that right now.