### PR TITLE
fix `.normalize` to handle uncertainties better

### DIFF
--- a/chromatic/rainbows/actions/normalization.py
+++ b/chromatic/rainbows/actions/normalization.py
@@ -1,7 +1,7 @@
 from ...imports import *
 
 
-def normalize(self, wavelength=True, time=False):
+def normalize(self, wavelength=True, time=False, percentile=50):
     """
     Normalize by dividing through by the median spectrum and/or lightcurve.
 
@@ -12,6 +12,15 @@ def normalize(self, wavelength=True, time=False):
 
     time : bool
         Should we divide by the median light curve?
+
+    percentile : float
+        A number between 0 and 100, specifying the percentile
+        of the data along an axis to use as the reference.
+        The default of `percentile=50` corresponds to the median.
+        If you want to normalize to out-of-transit, maybe you
+        want a higher percentile. If you want to normalize to
+        the baseline below a flare, maybe you want a lower
+        percentage.
 
     Returns
     -------
@@ -27,9 +36,9 @@ def normalize(self, wavelength=True, time=False):
         warnings.simplefilter("ignore")
 
         if time:
-            new = new / np.nanmedian(self.flux, axis=self.waveaxis)
+            new = new / np.nanpercentile(self.flux, axis=self.waveaxis)
 
         if wavelength:
-            new = new / np.nanmedian(self.flux, axis=self.timeaxis)
+            new = new / np.nanpercentile(self.flux, axis=self.timeaxis)
 
     return new

--- a/chromatic/rainbows/actions/normalization.py
+++ b/chromatic/rainbows/actions/normalization.py
@@ -1,17 +1,16 @@
 from ...imports import *
 
 
-def normalize(self, wavelength=True, time=False, percentile=50):
+def normalize(self, axis="wavelength", percentile=50):
     """
     Normalize by dividing through by the median spectrum and/or lightcurve.
 
     Parameters
     ----------
-    wavelength : bool
-        Should we divide by the median spectrum?
-
-    time : bool
-        Should we divide by the median light curve?
+    axis : str
+        The axis that should be normalized out.
+        `w` or `wave` or `wavelength` will divide out the typical spectrum.
+        `t` or `time` will divide out the typical light curve
 
     percentile : float
         A number between 0 and 100, specifying the percentile
@@ -35,10 +34,23 @@ def normalize(self, wavelength=True, time=False, percentile=50):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
 
-        if time:
-            new = new / np.nanpercentile(self.flux, axis=self.waveaxis)
-
-        if wavelength:
-            new = new / np.nanpercentile(self.flux, axis=self.timeaxis)
+        if axis.lower() == "w":
+            normalization = np.nanpercentile(new.flux, percentile, axis=self.timeaxis)
+            new.fluxlike["flux"] = new.flux / normalization[:, np.newaxis]
+            try:
+                new.fluxlike["uncertainty"] = (
+                    self.uncertainty / normalization[:, np.newaxis]
+                )
+            except ValueError:
+                pass
+        elif axis.lower() == "t":
+            normalization = np.nanpercentile(self.flux, percentile, axis=self.waveaxis)
+            new.fluxlike["flux"] = new.flux / normalization[np.newaxis, :]
+            try:
+                new.fluxlike["uncertainty"] = (
+                    self.uncertainty / normalization[np.newaxis, :]
+                )
+            except ValueError:
+                pass
 
     return new

--- a/chromatic/tests/test_rainbow_actions.py
+++ b/chromatic/tests/test_rainbow_actions.py
@@ -100,6 +100,26 @@ def test_bin_bad_data(visualize=False):
     return s
 
 
-def test_normalize():
-    s = SimulatedRainbow()
-    s.normalize()
+def test_normalize(plot=False):
+    N = 37
+    w = np.logspace(0, 1, N) * u.micron
+    f = np.cos(2 * np.pi * w.value / 3) + 1
+
+    snr = 100
+    a = SimulatedRainbow(signal_to_noise=snr, wavelength=w)
+    b = SimulatedRainbow(signal_to_noise=snr, wavelength=w, star_flux=f)
+    c = SimulatedRainbow(
+        signal_to_noise=snr, wavelength=w, star_flux=f
+    ).inject_transit()
+
+    for x in [a, b, c]:
+        nw = x.normalize(axis="w")
+        nt = x.normalize(axis="t")
+        nwt = x.normalize(axis="w").normalize(axis="t")
+        ntw = x.normalize(axis="t").normalize(axis="w")
+
+        for r in [nw, nt, nwt, ntw]:
+            r.fluxlike["relative-uncertainty"] = r.uncertainty / r.flux
+            assert np.all(np.isclose(r.uncertainty / r.flux, 1 / snr, rtol=0.1))
+            if plot:
+                r.imshow_fluxlike_quantities(maxcol=4)

--- a/chromatic/version.py
+++ b/chromatic/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.20"
+__version__ = "0.0.21"
 
 
 def version():


### PR DESCRIPTION
This pull request makes general improvements to the `.normalize` action, including:
- Now normalize uncertainties alongside fluxes. Not doing this was a major bug!
- Add a better `test_normalize()` to confirm uncertainties behave reasonably.
- Switch from `.nanmedian` to `.nanpercentile` to allow user to normalize to a different percentile value.
- No longer allow user to apply both wavelength and time normalization in the same step, because the order matters. Now, call with `rainbow.normalize(axis='wavelength')` or `rainbow.normalize(axis='time')` to normalize a particular axis. 

Closes #63 . 