### PR TITLE
Fix buggy binning

### DIFF
--- a/chromatic/rainbows/actions/__init__.py
+++ b/chromatic/rainbows/actions/__init__.py
@@ -1,3 +1,4 @@
 from .binning import *
+from .trim import *
 from .normalization import *
 from .wavelike import *

--- a/chromatic/rainbows/actions/binning.py
+++ b/chromatic/rainbows/actions/binning.py
@@ -15,6 +15,7 @@ def bin(
     wavelength=None,
     wavelength_edges=None,
     nwavelengths=None,
+    trim=True,
 ):
     """
     Bin in wavelength and/or time.
@@ -78,6 +79,10 @@ def bin(
         Binning will start from the 0th element of the
         starting wavelengths; if you want to start from
         a different index, trim before binning.
+    trim : bool
+        Should any wavelengths or columns that end up
+        as entirely nan be trimmed out of the result?
+        (default = True)
 
     Returns
     -------
@@ -86,7 +91,7 @@ def bin(
     """
     # bin first in time
     binned_in_time = self.bin_in_time(
-        dt=dt, time=time, time_edges=time_edges, ntimes=ntimes
+        dt=dt, time=time, time_edges=time_edges, ntimes=ntimes, trim=trim
     )
 
     # then bin in wavelength
@@ -96,13 +101,14 @@ def bin(
         wavelength=wavelength,
         wavelength_edges=wavelength_edges,
         nwavelengths=nwavelengths,
+        trim=trim,
     )
 
     # return the binned object
     return binned
 
 
-def bin_in_time(self, dt=None, time=None, time_edges=None, ntimes=None):
+def bin_in_time(self, dt=None, time=None, time_edges=None, ntimes=None, trim=True):
     """
     Bin in time.
 
@@ -134,6 +140,10 @@ def bin_in_time(self, dt=None, time=None, time_edges=None, ntimes=None):
         Binning will start from the 0th element of the
         starting times; if you want to start from
         a different index, trim before binning.
+    trim : bool
+        Should any wavelengths or columns that end up
+        as entirely nan be trimmed out of the result?
+        (default = True)
 
     Returns
     -------
@@ -186,13 +196,14 @@ def bin_in_time(self, dt=None, time=None, time_edges=None, ntimes=None):
     ok = self.is_ok()
     for k in self.fluxlike:
 
+        '''
         if k == "uncertainty":
             warnings.warn(
                 """
             Uncertainties and/or data quality flags might
             not be handled absolutely perfectly yet...
             """
-            )
+            )'''
 
         # loop through wavelengths
         for w in range(new.nwave):
@@ -234,11 +245,20 @@ def bin_in_time(self, dt=None, time=None, time_edges=None, ntimes=None):
     # figure out the scale, after binning
     new._guess_wscale()
 
-    return new
+    if trim:
+        return new.trim_nan_times()
+    else:
+        return new
 
 
 def bin_in_wavelength(
-    self, R=None, dw=None, wavelength=None, wavelength_edges=None, nwavelengths=None
+    self,
+    R=None,
+    dw=None,
+    wavelength=None,
+    wavelength_edges=None,
+    nwavelengths=None,
+    trim=True,
 ):
     """
     Bin in wavelength.
@@ -273,6 +293,10 @@ def bin_in_wavelength(
         Binning will start from the 0th element of the
         starting wavelengths; if you want to start from
         a different index, trim before binning.
+    trim : bool
+        Should any wavelengths or columns that end up
+        as entirely nan be trimmed out of the result?
+        (default = True)
 
     Returns
     -------
@@ -337,13 +361,14 @@ def bin_in_wavelength(
     ok = self.is_ok()
     for k in self.fluxlike:
 
+        '''
         if k == "uncertainty":
             warnings.warn(
                 """
             Uncertainties and/or data quality flags might
             not be handled absolutely perfectly yet...
             """
-            )
+            )'''
 
         for t in range(new.ntime):
 
@@ -384,4 +409,7 @@ def bin_in_wavelength(
     # figure out the scale, after binning
     new._guess_wscale()
     # new.metadata["wscale"] = wscale
-    return new
+    if trim:
+        return new.trim_nan_wavelengths()
+    else:
+        return new

--- a/chromatic/rainbows/actions/trim.py
+++ b/chromatic/rainbows/actions/trim.py
@@ -1,0 +1,53 @@
+from ...imports import *
+
+
+def trim_nan_times(self, threshold=1.0):
+    """
+    Trim times that are all (or mostly) not numbers.
+
+    Parameters
+    ----------
+    threshold
+        The fraction of wavelengths that must be nan in order for
+        the entire time to be considered bad (default = 1).
+    """
+
+    # figure out which times are good enough to keep
+    fraction_of_nans = np.sum(np.isnan(self.flux), axis=self.waveaxis) / self.nwave
+    indices_of_times_to_keep = fraction_of_nans < threshold
+
+    return self[:, indices_of_times_to_keep]
+
+
+def trim_nan_wavelengths(self, threshold=1.0):
+    """
+    Trim wavelengths that are all (or mostly) not numbers.
+
+    Parameters
+    ----------
+    threshold
+        The fraction of times that must be nan in order for
+        the entire wavelength to be considered bad (default = 1).
+    """
+
+    # figure out which times are good enough to keep
+    fraction_of_nans = np.sum(np.isnan(self.flux), axis=self.timeaxis) / self.ntime
+    indices_of_wavelengths_to_keep = fraction_of_nans < threshold
+
+    return self[indices_of_wavelengths_to_keep, :]
+
+
+def trim(self, threshold=1.0):
+    """
+    Trim wavelengths or times that are all (or mostly) not numbers.
+
+    Parameters
+    ----------
+    threshold
+        The fraction of a particular time/wavelengths that must be nan
+        in order for the entire wavelength/time to be considered bad
+        (default = 1).
+    """
+    trimmed = self.trim_nan_times(threshold=threshold)
+    trimmed = trimmed.trim_nan_wavelengths(threshold=threshold)
+    return trimmed

--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -611,6 +611,9 @@ class Rainbow:
         bin,
         bin_in_time,
         bin_in_wavelength,
+        trim,
+        trim_nan_times,
+        trim_nan_wavelengths,
         get_spectrum,
         get_spectral_resolution,
         plot_spectral_resolution,
@@ -628,7 +631,7 @@ class Rainbow:
         _setup_animated_scatter,
         _setup_wavelength_colors,
         _make_sure_cmap_is_defined,
-        get_wavelength_color, 
+        get_wavelength_color,
         imshow_fluxlike_quantities,
-        plot_quantities
+        plot_quantities,
     )

--- a/chromatic/tests/test_rainbow_binning.py
+++ b/chromatic/tests/test_rainbow_binning.py
@@ -165,3 +165,11 @@ def test_bin_bad_data(visualize=False):
 
     assert np.any(np.isfinite(b.flux))
     return s
+
+
+def test_bin_both():
+    bintime = 5
+    binwave = 0.1
+    w = np.logspace(0, 1) * u.micron
+    r = SimulatedRainbow(signal_to_noise=1000, dt=bintime * u.minute)
+    b_withouttransit = r.bin(dw=binwave * u.micron, dt=bintime * u.minute)

--- a/chromatic/tests/test_rainbow_trimming.py
+++ b/chromatic/tests/test_rainbow_trimming.py
@@ -1,0 +1,14 @@
+from ..rainbows import *
+from .setup_tests import *
+
+
+def test_trim():
+    r = SimulatedRainbow()
+    r.fluxlike["flux"][:3, :] = np.nan
+    r.fluxlike["flux"][:, -4:] = np.nan
+    original_shape = r.shape
+    t = r.trim()
+    new_shape = t.shape
+    assert new_shape[0] == original_shape[0] - 3
+    assert new_shape[1] == original_shape[1] - 4
+    print(r, t)


### PR DESCRIPTION
There were some bugs popping up from the reworked binning options. In particular, sometimes binning appears to create an empty time or wavelength, which then turns into nans. This was causing errors in subsequent binning calls, when being asked to bin a row or column of all nan. 

It should now be better in two ways:
1. `bintogrid` will no longer complain if being asked to bin all nan data. It will return nans, in the appropriate shape.
2. We added a `.trim` function to trim wavelengths or times that contain no good values, and we added this `.trim` as a default (but still optional) step to all binning, to prevent rainbows from carrying around useless empty wavelengths or times.
