### PR TITLE
fix wavelength labels in .plot for unnormalized data

### DIFF
--- a/chromatic/rainbows/visualizations/plot.py
+++ b/chromatic/rainbows/visualizations/plot.py
@@ -95,7 +95,7 @@ def plot(
                 this_textkw.update(**textkw)
                 plt.annotate(
                     f"{w.to(w_unit).value:.2f} {w_unit.to_string('latex_inline')}",
-                    (min_time, 1 - (i + 0.5) * spacing),
+                    (min_time, np.median(plot_flux) - 0.5 * spacing),
                     **this_textkw,
                 )
 

--- a/chromatic/tests/test_rainbow_visualizations.py
+++ b/chromatic/tests/test_rainbow_visualizations.py
@@ -35,6 +35,13 @@ def test_plot():
     plt.savefig(os.path.join(test_directory, "plot-demonstration.pdf"))
 
 
+def test_plot_unnormalized():
+    w = np.logspace(0, 1, 5) * u.micron
+    s = SimulatedRainbow(wavelength=w, star_flux=w.value ** 2, signal_to_noise=5)
+    s.plot(spacing=0)
+    plt.savefig(os.path.join(test_directory, "plot-demonstration-unnormalized.pdf"))
+
+
 def test_plot_quantities():
     r = SimulatedRainbow(R=10)
     for k in "abcdefg":

--- a/chromatic/tests/test_rainbow_visualizations.py
+++ b/chromatic/tests/test_rainbow_visualizations.py
@@ -37,6 +37,7 @@ def test_plot():
 
 def test_plot_unnormalized():
     w = np.logspace(0, 1, 5) * u.micron
+    plt.figure()
     s = SimulatedRainbow(wavelength=w, star_flux=w.value ** 2, signal_to_noise=5)
     s.plot(spacing=0)
     plt.savefig(os.path.join(test_directory, "plot-demonstration-unnormalized.pdf"))


### PR DESCRIPTION
I edited the label location in .plot function from 1 - (I + 0.5)*spacing to np.median(plot_flux) - 0.5 * spacing