### PR TITLE
reorganize documentation into "User" and "Developer"

### DIFF
--- a/chromatic/rainbows/multi.py
+++ b/chromatic/rainbows/multi.py
@@ -388,7 +388,7 @@ class MultiRainbow:
             The minimum value to use for the wavelength colormap.
         vmax : astropy.units.Quantity
             The maximum value to use for the wavelength colormap.
-        plowkw : dict
+        plotkw : dict
             A dictionary of keywords passed to `plt.plot`
         textkw : dict
             A dictionary of keywords passed to `plt.text`

--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -620,8 +620,9 @@ class Rainbow:
         print(
             textwrap.dedent(
                 """
-        Hooray for you! You asked for help on what you can do with this 🌈 object.
-        Here's a quick reference of a few available options for things to try."""
+        Hooray for you! You asked for help on what you can do
+        with this 🌈 object. Here's a quick reference of a few
+        available options for things to try."""
             )
         )
 
@@ -644,7 +645,9 @@ class Rainbow:
                 else:
                     function_call = f".{row['name']}()"
 
-                item = f"{row['cartoon']} | {function_call:<28} | {row['description']}"
+                item = (
+                    f"{row['cartoon']} | {function_call:<28} \n   {row['description']}"
+                )
                 print(item)
 
     # import the basic operations for Rainbows

--- a/chromatic/rainbows/visualizations/plot.py
+++ b/chromatic/rainbows/visualizations/plot.py
@@ -36,7 +36,7 @@ def plot(
         The minimum value to use for the wavelength colormap.
     vmax : astropy.units.Quantity
         The maximum value to use for the wavelength colormap.
-    plowkw : dict
+    plotkw : dict
         A dictionary of keywords passed to `plt.plot`
     textkw : dict
         A dictionary of keywords passed to `plt.text`

--- a/chromatic/rainbows/writers/text.py
+++ b/chromatic/rainbows/writers/text.py
@@ -10,7 +10,7 @@ from ...imports import *
 __all__ = ["to_text"]
 
 
-def to_text(rainbow, filepath, overwrite=None, group_by="wavelength"):
+def to_text(rainbow, filepath, overwrite=True, group_by="wavelength"):
     """
     Write a Rainbow to a file in the text format.
 

--- a/docs/actions.ipynb
+++ b/docs/actions.ipynb
@@ -372,7 +372,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,5 +9,3 @@
         - normalize
         - imshow
         - plot
-        - animate_lightcurves
-        - animate_spectra

--- a/docs/basics.ipynb
+++ b/docs/basics.ipynb
@@ -128,7 +128,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*(Doesn't exist yet but hopefully will soon...)* The **ok** property is a 2D array indicating whether a particular flux data point is good (`True`) or bad (`False`)."
+    "The **ok** property is a 2D array indicating whether a particular flux data point is good (`True`) or bad (`False`). It's a place to keep track of what data should be ignored when fitting or visualizing. "
    ]
   },
   {
@@ -137,82 +137,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "'''# access the 2D array of times\n",
+    "# access the 2D array of times\n",
     "print(f'The {r.nflux} `ok` mask values...')\n",
-    "print(f'  have a shape of {s.ok.shape},')\n",
-    "print(f'  a type of {type(s.ok)},')\n",
-    "print(f'  a dtype of {s.ok.dtype}')''';"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## How does it look inside? "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "*If you don't want to know what's happening behind the scenes, feel free to skip this section.* If you want to look more closely at what's happening inside a `Rainbow` object, these properties are being pulled from some core dictionaries. You don't need to interact with these at all if you don't want to, but we describe them here in case you want to understand what's happening a little more clearly or if you want to add any new features of your own.\n",
-    "\n",
-    "These are designed to store quantities that have dimensions like either `wavelength`, `time`, or `flux`:\n",
-    "- `.wavelike[...]` contains everything that has the same dimensions as `wavelength`. This dictionary will contain at least a `'wavelength'` key, with the actual wavelengths themselves. It might *also* contain information like the average spectrum of the star, the average S/N at each wavelength, the number of original detector pixels that wound up in this particular wavelength bin, and/or a mask of what wavelengths should be considered good or bad (no matter the time point). \n",
-    "- `.timelike[...]` contains everything that has the same dimensons as `time`. This dictionary will contain at least a `'time'` key, with the actual times themselves. It might *also* contain information like a broadband light curve of the transit, the x or y position of the spectrum on the detector, the temperature of the detector, and/or a mask of what times should be considered good or bad (no matter the wavelength).\n",
-    "- `.fluxlike[...]` contains everything that has the same dimensons as `flux`. This dictionary will contain at least a `'flux'` key, with the actual fluxes themselves. It should also contain an `'uncertainty'` keyword with the uncertainties associated with those fluxes (or maybe `None`). It might *also* contain information about other quantities that depend on both time and wavelength, such as the centroid of the spectral trace, the maximum fraction of saturation, and/or a mask of what individual points should be considered good or bad.\n",
-    "\n",
-    "There is one more core dictionary:\n",
-    "- `.metadata` contains general information that might be useful to hang onto, to pass along to another derived object, or to save out to a file"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "r.wavelike.keys()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "r.timelike.keys()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "r.fluxlike.keys()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "r.metadata.keys()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "When you call something like `.wavelength`, `.time`, `.flux`, they are being pulled directly from these dictionaries. This means you generally can't do something like `r.wavelength = 5`; if you want to (very carefully and with an understanding you might break things) change the values of something being pulled from a core dictionary, you need to explicitly say `r.wavelike['wavelength'] = 5`."
+    "print(f'  have a shape of {r.ok.shape},')\n",
+    "print(f'  a type of {type(r.ok)},')\n",
+    "print(f'  a dtype of {r.ok.dtype}')"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -226,7 +161,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/docs/creating.ipynb
+++ b/docs/creating.ipynb
@@ -5,7 +5,7 @@
    "id": "fbc32de2",
    "metadata": {},
    "source": [
-    "# Creating a 🌈\n",
+    "# Creating a 🌈  from Arrays\n",
     "\n",
     "You can create a `Rainbow` object from arrays representing wavelength, time, flux, and any other array quantities that have the same shape as one of those first three. This creates some (very cartoonish) simulated datasets of time-series spectra, and shows how to construct 🌈s out of them."
    ]
@@ -368,7 +368,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/docs/designing.ipynb
+++ b/docs/designing.ipynb
@@ -1,0 +1,210 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "04789f75",
+   "metadata": {},
+   "source": [
+    "# Designing New 🌈 Features\n",
+    "\n",
+    "The `Rainbow` class is the heart of `chromatic`. We aim for it to be as intuitive and easy-to-use as possible, to enable transparent and repeatable analysis of spectrosopic time-series datasets. This page collects a few explanations that might be useful if you're trying to develop new  `Rainbow` features."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49044afc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from chromatic import *"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d6f9fa4",
+   "metadata": {},
+   "source": [
+    "## How are `Rainbow` objects organized? \n",
+    "\n",
+    "The user mainly interacts with quantities like time, wavelength, and flux via the `.time`, `.wavelength`, `.flux` attributes. However, if you more closely at what's happening inside a `Rainbow` object, you'll see that these are properties that pull data from some core dictionaries. The general user probably doesn't need to interact with the core dictionaries, but if you're developing new features for `Rainbow` objects you will want to understand what's happening a little more clearly.\n",
+    "\n",
+    "The core dictionaries are designed to store quantities that have dimensions like either `wavelength`, `time`, or `flux`:\n",
+    "- `.wavelike[...]` contains everything that has the same dimensions as `wavelength`. This dictionary will contain at least a `'wavelength'` key, with the actual wavelengths themselves. It might *also* contain information like the average spectrum of the star, the average S/N at each wavelength, the number of original detector pixels that wound up in this particular wavelength bin, and/or a mask of what wavelengths should be considered good or bad (no matter the time point). \n",
+    "- `.timelike[...]` contains everything that has the same dimensons as `time`. This dictionary will contain at least a `'time'` key, with the actual times themselves. It might *also* contain information like a broadband light curve of the transit, the x or y position of the spectrum on the detector, the temperature of the detector, and/or a mask of what times should be considered good or bad (no matter the wavelength).\n",
+    "- `.fluxlike[...]` contains everything that has the same dimensons as `flux`. This dictionary will contain at least a `'flux'` key, with the actual fluxes themselves. It should also contain an `'uncertainty'` keyword with the uncertainties associated with those fluxes (or maybe `None`). It might *also* contain information about other quantities that depend on both time and wavelength, such as the centroid of the spectral trace, the maximum fraction of saturation, and/or a mask of what individual points should be considered good or bad.\n",
+    "\n",
+    "There is one more core dictionary:\n",
+    "- `.metadata` contains general information that might be useful to hang onto, to pass along to another derived object, or to save out to a file. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "662d4dce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = SimulatedRainbow()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15a52351",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.wavelike.keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dab4db11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.timelike.keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7d5e868",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.fluxlike.keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "231dc17d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.metadata.keys()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51395c42",
+   "metadata": {},
+   "source": [
+    "When you retrieve variables with something like `.wavelength`, `.time`, `.flux`, data is being pulled directly from these dictionaries. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66c094fb",
+   "metadata": {},
+   "source": [
+    "## What can `Rainbow` objects do? "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47eca959",
+   "metadata": {},
+   "source": [
+    "We defined a small lexicon of things that `Rainbow` objects can do. If you want to write a new feature, hopefully it fits into one of these categories. If not, we can certainly discuss adding new ones!\n",
+    "\n",
+    "- **actions** return a new `Rainbow` object as the result. As such, they can be chained together into commands like `r.bin(R=5).normalize().plot()`.\n",
+    "- **visualizations** create some graphical representation of the data in a `Rainbow`.\n",
+    "- **wavelike_summaries** return a wavelike-shaped summary of a `Rainbow`, with one quantity for each wavelength.\n",
+    "- **timelike_summaries** return a timelike-shaped summary of a `Rainbow`, with one quantity for each time.\n",
+    "\n",
+    "Each of these categories has its own directory inside `chromatic/rainbows/` where the corresponding code should be stored. The `.help()` method attached to any `Rainbow` will list everything you can do with it. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5df1edd2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.help()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c638271d",
+   "metadata": {},
+   "source": [
+    "## How do we add new abilities to `Rainbow` objects?\n",
+    "\n",
+    "If you want to add a new method to a `Rainbow` object, there are a few general steps you'll probably want to follow.\n",
+    "\n",
+    "1. Install in development mode (see [Installation](../../installation)), so you can modify the code package directly and test the code in place.\n",
+    "1. Decide a category of \"things a `Rainbow` can do\" in which it belongs.\n",
+    "1. Find the directory for that category in the `chromatic` code package. For example, \"actions\" that return new `Rainbow` objects will be in `chromatic/rainbows/actions/`. \n",
+    "1. Look at another example in that directory to get a sense for the general layout. For example, you'll notice that \"actions\" generally create a copy of `self`, make some changes to that copy, and then return it as the new object. \n",
+    "1. Add your new function, either to an existing `.py` file where it would make sense or to its own new `.py` file. The first argument to your function should be `self`, which is the `Rainbow` object itself, and then any additional arguments should follow afterward. A good way to test out your new function in a notebook or a small isolated script might look something like the following:\n",
+    "```python\n",
+    "from chromatic import *\n",
+    "r = SimulatedRainbow()\n",
+    "def snazzy_new_action(self, x=2):\n",
+    "    \n",
+    "    # create a copy of the original object\n",
+    "    new = self._create_copy()\n",
+    "    \n",
+    "    # do something\n",
+    "    new.fluxlike['flux'] = new.flux**x\n",
+    "    \n",
+    "    # return the modified copy\n",
+    "    return new\n",
+    "output = snazzy_new_action(r)\n",
+    "```\n",
+    "This allows you to develop and test your new function without having to worry about it being imported properly into the core `Rainbow` definition. \n",
+    "1. Connect your new function into the `Rainbow` class definition. Normally, we might define a new method directly in the same file as the class definition itself, but we wanted to split the method definitions into multiple files and directories, to make things easier to find. Importing your new function to become a `Rainbow` method takes a few steps. For example, let's imagine you're making a new \"action\" called `snazzy_new_action` and it's located in `chromatic/rainbows/actions/snazzy.py`:\n",
+    "    - In `rainbows/actions/snazzy.py`, include line of code like `__all__ = ['snazzy_new_action']` at the top. The `__all__` list defines what would get imported via a line like `from chromatic.rainbows.actions.snazzy import *` (things not in `__all__` will need to be explicitly imported). \n",
+    "    - In `rainbows/actions/__init__.py`, include a line of code like `from .snazzy import *`, so that imports from `chromatic.rainbows.actions` will know how to find things in `snazzy.py`. \n",
+    "    - In `rainbows/rainbow.py`, down at the very bottom of the class definition for `Rainbow`, add `snazzy_new_action` to the list of `from .actions import (...)`. This, finally, will mean that all `Rainbow` objects will have access to your new method, and we can do things like `r.snazzy_new_action()` from any `Rainbow`.\n",
+    "    - In `rainbows/actions/descriptions.txt`, add a row describing your snazzy new action. This table defines what appears in the `.help()` method.\n",
+    "1. Write a test for your new feature. This is a function that somehow tests whether your new feature works; the simplest form would be \"does this function run\", a slightly fancier version would be \"are its outputs accurate.\" To write a test:\n",
+    "    - Look in `chromatic/tests/` to find a bunch of `test_*.py` files with examples of automated tests in them. \n",
+    "    - Create a function that has `*test*` somewhere in its name and store it somewhere in the `tests` directory. At a minimum, this function should test that the bit of code you wrote runs without breaking. \n",
+    "    - Run `pytest` from the command line within the main repository directory. This will run your test function (along with all the other tests) and tell you whether it passed or failed. Make sure it passes!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3901e7b6",
+   "metadata": {},
+   "source": [
+    "## How do we add new readers/writers for `Rainbow` objects?\n",
+    "\n",
+    "You might want to create a new reader or writer, to allow `chromatic` to interact with your own datasets or tools. To facilitate this, templates are available with human-friendly instructions for how to add a new reader or writer. If you want to try to incorporate a new reader or writer, please:\n",
+    "1. Install in development mode (see [Installation](../../installation)), so you can modify the code package directly and test the code in place.\n",
+    "2. Navigate to `chromatic/rainbows/[readers|writers]/template.py`.\n",
+    "3. Follow the instructions in the comments in that file.\n",
+    "\n",
+    "Good luck! "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/documentation.ipynb
+++ b/docs/documentation.ipynb
@@ -1,0 +1,39 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0c858c15",
+   "metadata": {},
+   "source": [
+    "# Writing 🌈 Documentation\n",
+    "\n",
+    "If you're contributing a new feature to `chromatic`, please consider also contributing some documentation to explain how your feature works. Here's the very short version of how to add to the documentation:\n",
+    "\n",
+    "1. Install in development mode (see [Installation](../../installation)), so you have access to `mkdocs` and the various extensions needed to render the documentation.\n",
+    "1. Decide whether your explanation would fit well within an existing page or whether you need a new one. In the `docs/` directory, find the appropraite `.ipynb` notebook file or create a new one. If you create a new one, add it to the `nav:` section of the `mkdocs.yml` file in the main repository directory so that `mkdocs` will know to include it.\n",
+    "1. Write your example and explanation. Your audience should be smart people who want to use the code but don't have much experience with it yet. Be friendly and encouraging!\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/github.ipynb
+++ b/docs/github.ipynb
@@ -1,0 +1,43 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1c9b17bb",
+   "metadata": {},
+   "source": [
+    "# Contributing 🌈 Code with `github`\n",
+    "\n",
+    "There are oodles of great tutorials on various aspects of contributing to collaborative code projects with `github`. This page is meant to provide a quick, recipe-like answer to the question \"how do I contribute some code to the `chromatic` package?\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f91bc20b",
+   "metadata": {},
+   "source": [
+    "(coming soon...)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/installation.ipynb
+++ b/docs/installation.ipynb
@@ -55,7 +55,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -69,7 +69,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/docs/io.ipynb
+++ b/docs/io.ipynb
@@ -290,14 +290,8 @@
    "id": "34ee8df0",
    "metadata": {},
    "source": [
-    "## Create your Own!\n",
-    "\n",
-    "Naturally, you might want to add new readers to make use of the outputs from other pipelines or new writers to feed into various light curve analyses. To facilitate this, templates are available with human-friendly instructions for how to add a new reader or writer. If you want to try to incorporate a new reader or writer, please:\n",
-    "1. Install in development mode (see the [installation instructions](../installation))\n",
-    "2. Navigate to `chromatic/rainbows/[readers|writers]/template.py`.\n",
-    "3. Follow the instructions.\n",
-    "\n",
-    "Good luck! If you add something, please consider submitting a Pull Request to share it with the world!"
+    "## Create Your Own!\n",
+    "Naturally, you might want to add new readers to make use of the outputs from other pipelines or new writers to feed into various light curve analyses. See [Design Principles](../develop/principles) to learn how!"
    ]
   }
  ],
@@ -317,7 +311,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -128,13 +128,31 @@
    "id": "3d5f3274",
    "metadata": {},
    "source": [
-    "Here you've seen some of the basic functionality of what `chromatic` can do. Please read on to learn more about reading a 🌈 from a real data file, doing actions on/with a 🌈, and visualizing a 🌈 in different ways!"
+    "Here you've seen some of the basic functionality of what `chromatic` can do. To figure out what other options are available for any particular `Rainbow` object, you can run the `.help()` method, like this: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "abc9595d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.help()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04013095",
+   "metadata": {},
+   "source": [
+    "Please read on through the documentation to learn about reading a 🌈 from a real data file, doing actions on/with a 🌈, visualizing a 🌈 in different ways, and more! "
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -148,7 +166,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,16 +1,20 @@
 site_name: chromatic
 site_url: https://zkbt.github.com/chromatic
 nav:
-    #- Home: index.md
+    - index.md
     - installation.ipynb
     - quickstart.ipynb
-    - basics.ipynb
-    - io.ipynb
-    - creating.ipynb
-    - actions.ipynb
-    - visualizing.ipynb
-    - multi.ipynb
-    - api.md
+    - User Guide:
+      - basics.ipynb
+      - io.ipynb
+      - creating.ipynb
+      - actions.ipynb
+      - visualizing.ipynb
+      - multi.ipynb
+    - Developer Guide:
+        - designing.ipynb
+        - documentation.ipynb
+        - github.ipynb
 theme:
   name: "material"
   features:
@@ -36,6 +40,8 @@ plugins:
       glob:
         - "example-datasets/*"
         - "*.pdf"
-
+markdown_extensions:
+    - toc:
+        permalink: "#"
 # this is super borrowed from Christina Hedges' fabulous
 # https://christinahedges.github.io/astronomy_workflow/


### PR DESCRIPTION
Make some changes to the documentation at [zkbt.github.io/chromatic](https://zkbt.github.io/chromatic/). Main aspects:
- Split into User and Developer sections, to skip over more complicated stuff for people just starting out. 
- Add some design + documentation tips.
- Create placeholder for github tips.
- Add `.help()` to quickstart.
- Minor edits throughout.
