### PR TITLE
Added convertors for rainbow to numpy arrays and to pandas dataframe

### DIFF
--- a/chromatic/imports.py
+++ b/chromatic/imports.py
@@ -36,6 +36,9 @@ from scipy.interpolate import interp1d
 # For modelling transits.
 import batman
 
+# For converting Rainbows to pandas dataframe
+import pandas as pd
+
 from .units import *
 
 # define a driectory where we can put any necessary data files

--- a/chromatic/rainbows/actions/__init__.py
+++ b/chromatic/rainbows/actions/__init__.py
@@ -2,3 +2,4 @@ from .binning import *
 from .trim import *
 from .normalization import *
 from .align_wavelengths import *
+from .conversions import *

--- a/chromatic/rainbows/actions/conversions.py
+++ b/chromatic/rainbows/actions/conversions.py
@@ -3,8 +3,8 @@ from ...imports import *
 __all__ = ["to_nparray", "to_df"]
 
 
-def to_nparray(self, t_unit='d', w_unit='micron'):
-    """ Convert Rainbow object to 1D and 2D numpy arrays
+def to_nparray(self, t_unit="d", w_unit="micron"):
+    """Convert Rainbow object to 1D and 2D numpy arrays
     Parameters
     ----------
         self : Rainbow object
@@ -27,10 +27,18 @@ def to_nparray(self, t_unit='d', w_unit='micron'):
             wavelength (w_unit)    [n_wavelengths]
     """
 
-    rflux = np.array(self.fluxlike['flux'])  # flux                       : [n_wavelengths x n_integrations]
-    rfluxu = np.array(self.fluxlike['uncertainty'])  # uncertainty        : [n_wavelengths x n_integrations]
-    rtime = self.timelike['time']  # time (BJD_TDB, hours)                : [n_integrations]
-    rwavel = self.wavelike['wavelength']  # wavelength (microns)          : [n_wavelengths]
+    rflux = np.array(
+        self.fluxlike["flux"]
+    )  # flux                       : [n_wavelengths x n_integrations]
+    rfluxu = np.array(
+        self.fluxlike["uncertainty"]
+    )  # uncertainty        : [n_wavelengths x n_integrations]
+    rtime = self.timelike[
+        "time"
+    ]  # time (BJD_TDB, hours)                : [n_integrations]
+    rwavel = self.wavelike[
+        "wavelength"
+    ]  # wavelength (microns)          : [n_wavelengths]
 
     try:
         # nice bit of code copied from .imshow(), thanks Zach!
@@ -38,22 +46,22 @@ def to_nparray(self, t_unit='d', w_unit='micron'):
         t_unit = u.Unit(t_unit)
     except:
         warnings.warn("Unrecognised Time Format! Returning day by default")
-        t_unit = u.Unit('d')
-    rtime = np.array((rtime / t_unit).decompose())
+        t_unit = u.Unit("d")
+    rtime = np.array(rtime.to(t_unit).value)
 
     try:
         # Change wavelength into the units requested by the user
         w_unit = u.Unit(w_unit)
     except:
         warnings.warn("Unrecognised Wavelength Format! Returning micron by default")
-        w_unit = u.Unit('micron')
-    rwavel = np.array((rwavel / w_unit).decompose())
+        w_unit = u.Unit("micron")
+    rwavel = np.array(rwavel.to(w_unit).value)
 
     return rflux, rfluxu, rtime, rwavel
 
 
-def to_df(self, t_unit='d', w_unit='micron'):
-    """ Convert Rainbow object to pandas dataframe
+def to_df(self, t_unit="d", w_unit="micron"):
+    """Convert Rainbow object to pandas dataframe
     Parameters
     ----------
         self : Rainbow object
@@ -70,12 +78,16 @@ def to_df(self, t_unit='d', w_unit='micron'):
             The rainbow object flattened and converted into a pandas dataframe
     """
     # extract 1D/2D formats for the flux, uncertainty, time and wavelengths
-    rflux, rfluxu, rtime, rwavel = self.to_nparray(t_unit=t_unit,w_unit=w_unit)
+    rflux, rfluxu, rtime, rwavel = self.to_nparray(t_unit=t_unit, w_unit=w_unit)
 
     # put all arrays onto same dimensions
     x, y = np.meshgrid(rtime, rwavel)
-    rainbow_dict = {f"Time ({t_unit})": x.ravel(), f"Wavelength ({w_unit})": y.ravel(), "Flux": rflux.ravel(),
-                    "Flux Uncertainty": rfluxu.ravel()}
+    rainbow_dict = {
+        f"Time ({t_unit})": x.ravel(),
+        f"Wavelength ({w_unit})": y.ravel(),
+        "Flux": rflux.ravel(),
+        "Flux Uncertainty": rfluxu.ravel(),
+    }
 
     # convert to pandas dataframe
     df = pd.DataFrame(rainbow_dict)

--- a/chromatic/rainbows/actions/conversions.py
+++ b/chromatic/rainbows/actions/conversions.py
@@ -3,75 +3,78 @@ from ...imports import *
 __all__ = ["to_nparray", "to_df"]
 
 
-def to_nparray(self, timeformat='d'):
+def to_nparray(self, t_unit='d', w_unit='micron'):
     """ Convert Rainbow object to 1D and 2D numpy arrays
     Parameters
     ----------
         self : Rainbow object
             chromatic Rainbow object to convert into array format
-        timeformat : str
+        t_unit : str
             (optional, default='d')
-            The time format to use (seconds, minutes, hours, days etc.)
+            The time units to use (seconds, minutes, hours, days etc.)
+        w_unit : str
+            (optional, default='micron')
+            The wavelength units to use
     Returns
     ----------
         rflux : np.array
-            flux                  [n_wavelengths x n_integrations]
+            flux                   [n_wavelengths x n_integrations]
         rfluxu : np.array
-            flux uncertainty      [n_wavelengths x n_integrations]
+            flux uncertainty       [n_wavelengths x n_integrations]
         rtime : np.array
-            time (BJD_TDB, hours) [n_integrations]
+            time (t_unit)          [n_integrations]
         rwavel : np.array
-            wavelength (microns)  [n_wavelengths]
+            wavelength (w_unit)    [n_wavelengths]
     """
-    secondformat = ['second', 'seconds', 'sec', 's']
-    minuteformat = ['minute', 'minutes', 'min', 'm']
-    hourformat = ['hour', 'hours', 'h']
-    dayformat = ['day', 'days', 'd']
-    yearformat = ['year', 'years', 'y']
 
-    rflux  = np.array(self.fluxlike['flux'])  # flux                         : [n_wavelengths x n_integrations]
-    rfluxu = np.array(self.fluxlike['uncertainty'])  # uncertainty           : [n_wavelengths x n_integrations]
-    rtime  = np.array(self.timelike['time'])  # time (BJD_TDB, hours)        : [n_integrations]
-    rwavel  = np.array(self.wavelike['wavelength'])  # wavelength (microns)  : [n_wavelengths]
+    rflux = np.array(self.fluxlike['flux'])  # flux                       : [n_wavelengths x n_integrations]
+    rfluxu = np.array(self.fluxlike['uncertainty'])  # uncertainty        : [n_wavelengths x n_integrations]
+    rtime = self.timelike['time']  # time (BJD_TDB, hours)                : [n_integrations]
+    rwavel = self.wavelike['wavelength']  # wavelength (microns)          : [n_wavelengths]
 
-    # change the time array into the requested format (e.g. seconds, minutes, days etc.)
-    if timeformat in secondformat:
-        rtime = rtime * 3600
-    elif timeformat in minuteformat:
-        rtime = rtime * 60
-    elif timeformat in hourformat:
-        pass
-    elif timeformat in dayformat:
-        # hours is the default time setting
-        rtime = rtime / 24.
-    elif timeformat in yearformat:
-        rtime = rtime / (24 * 365.)
-    else:
-        warnings.warn("Unrecognised Time Format!")
-        return
+    try:
+        # nice bit of code copied from .imshow(), thanks Zach!
+        # Change time into the units requested by the user
+        t_unit = u.Unit(t_unit)
+    except:
+        warnings.warn("Unrecognised Time Format! Returning day by default")
+        t_unit = u.Unit('d')
+    rtime = np.array((rtime / t_unit).decompose())
+
+    try:
+        # Change wavelength into the units requested by the user
+        w_unit = u.Unit(w_unit)
+    except:
+        warnings.warn("Unrecognised Wavelength Format! Returning micron by default")
+        w_unit = u.Unit('micron')
+    rwavel = np.array((rwavel / w_unit).decompose())
 
     return rflux, rfluxu, rtime, rwavel
 
 
-def to_df(self, timeformat='d'):
+def to_df(self, t_unit='d', w_unit='micron'):
     """ Convert Rainbow object to pandas dataframe
     Parameters
     ----------
         self : Rainbow object
             chromatic Rainbow object to convert into pandas df format
-        timeformat : str
+        t_unit : str
             (optional, default='d')
-            The time format to use (seconds, minutes, hours, days etc.)
+            The time units to use (seconds, minutes, hours, days etc.)
+        w_unit : str
+            (optional, default='micron')
+            The wavelength units to use
     Returns
     ----------
         pd.DataFrame
+            The rainbow object flattened and converted into a pandas dataframe
     """
     # extract 1D/2D formats for the flux, uncertainty, time and wavelengths
-    rflux, rfluxu, rtime, rwavel = self.to_nparray(timeformat)
+    rflux, rfluxu, rtime, rwavel = self.to_nparray(t_unit=t_unit,w_unit=w_unit)
 
     # put all arrays onto same dimensions
     x, y = np.meshgrid(rtime, rwavel)
-    rainbow_dict = {f"Time ({timeformat})": x.ravel(), "Wavelength (microns)": y.ravel(), "Flux": rflux.ravel(),
+    rainbow_dict = {f"Time ({t_unit})": x.ravel(), f"Wavelength ({w_unit})": y.ravel(), "Flux": rflux.ravel(),
                     "Flux Uncertainty": rfluxu.ravel()}
 
     # convert to pandas dataframe

--- a/chromatic/rainbows/actions/conversions.py
+++ b/chromatic/rainbows/actions/conversions.py
@@ -1,0 +1,79 @@
+from ...imports import *
+
+__all__ = ["to_nparray", "to_df"]
+
+
+def to_nparray(self, timeformat='h'):
+    """ Convert Rainbow object to 1D and 2D numpy arrays
+    Parameters
+    ----------
+        self : Rainbow object
+            chromatic Rainbow object to convert into array format
+        timeformat : str
+            (optional, default='hours')
+            The time format to use (seconds, minutes, hours, days etc.)
+    Returns
+    ----------
+        rflux : np.array
+            flux (MJy/sr)        [n_wavelengths x n_integrations]
+        rfluxe : np.array
+            flux error (MJy/sr)  [n_wavelengths x n_integrations]
+        rtime : np.array
+            time (BJD_TDB, houra) [n_integrations]
+        rwavel : np.array
+            wavelength (microns) [n_wavelengths]
+    """
+    secondformat = ['second', 'seconds', 'sec', 's']
+    minuteformat = ['minute', 'minutes', 'min', 'm']
+    hourformat = ['hour', 'hours', 'h']
+    dayformat = ['day', 'days', 'd']
+    yearformat = ['year', 'years', 'y']
+
+    rflux = np.array(self.fluxlike['flux'])  # flux (MJy/sr)                : [n_wavelengths x n_integrations]
+    rfluxe = np.array(self.fluxlike['uncertainty'])  # flux error (MJy/sr)  : [n_wavelengths x n_integrations]
+    rtime = np.array(self.timelike['time'])  # time (BJD_TDB, hours)        : [n_integrations]
+    rwavel = np.array(self.wavelike['wavelength'])  # wavelength (microns)  : [n_wavelengths]
+
+    # change the time array into the requested format (e.g. seconds, minutes, days etc.)
+    if timeformat in secondformat:
+        rtime = rtime * 3600
+    elif timeformat in minuteformat:
+        rtime = rtime * 60
+    elif timeformat in hourformat:
+        # hours is the default time setting
+        pass
+    elif timeformat in dayformat:
+        rtime = rtime / 24.
+    elif timeformat in yearformat:
+        rtime = rtime / (24 * 365.)
+    else:
+        warnings.warn("Unrecognised Time Format!")
+        return
+
+    return rflux, rfluxe, rtime, rwavel
+
+
+def to_df(self, timeformat='h'):
+    """ Convert Rainbow object to pandas dataframe
+    Parameters
+    ----------
+        self : Rainbow object
+            chromatic Rainbow object to convert into pandas df format
+        timeformat : str
+            (optional, default='hours')
+            The time format to use (seconds, minutes, hours, days etc.)
+    Returns
+    ----------
+        pd.DataFrame
+    """
+    # extract 1D/2D formats for the flux, uncertainty, time and wavelengths
+    rflux, rfluxe, rtime, rwavel = self.to_nparray(timeformat)
+
+    # put all arrays onto same dimensions
+    x, y = np.meshgrid(rtime, rwavel)
+    rainbow_dict = {f"Time ({timeformat})": x.ravel(), "Wavelength (microns)": y.ravel(), "Flux": rflux.ravel(),
+                    "Flux Error": rfluxe.ravel()}
+
+    # convert to pandas dataframe
+    df = pd.DataFrame(rainbow_dict)
+    return df

--- a/chromatic/rainbows/actions/conversions.py
+++ b/chromatic/rainbows/actions/conversions.py
@@ -15,7 +15,7 @@ def to_nparray(self, timeformat='d'):
     Returns
     ----------
         rflux : np.array
-            flux (MJy/sr)         [n_wavelengths x n_integrations]
+            flux                  [n_wavelengths x n_integrations]
         rfluxu : np.array
             flux uncertainty      [n_wavelengths x n_integrations]
         rtime : np.array

--- a/chromatic/rainbows/actions/conversions.py
+++ b/chromatic/rainbows/actions/conversions.py
@@ -3,25 +3,25 @@ from ...imports import *
 __all__ = ["to_nparray", "to_df"]
 
 
-def to_nparray(self, timeformat='h'):
+def to_nparray(self, timeformat='d'):
     """ Convert Rainbow object to 1D and 2D numpy arrays
     Parameters
     ----------
         self : Rainbow object
             chromatic Rainbow object to convert into array format
         timeformat : str
-            (optional, default='hours')
+            (optional, default='d')
             The time format to use (seconds, minutes, hours, days etc.)
     Returns
     ----------
         rflux : np.array
-            flux (MJy/sr)        [n_wavelengths x n_integrations]
-        rfluxe : np.array
-            flux error (MJy/sr)  [n_wavelengths x n_integrations]
+            flux (MJy/sr)         [n_wavelengths x n_integrations]
+        rfluxu : np.array
+            flux uncertainty      [n_wavelengths x n_integrations]
         rtime : np.array
-            time (BJD_TDB, houra) [n_integrations]
+            time (BJD_TDB, hours) [n_integrations]
         rwavel : np.array
-            wavelength (microns) [n_wavelengths]
+            wavelength (microns)  [n_wavelengths]
     """
     secondformat = ['second', 'seconds', 'sec', 's']
     minuteformat = ['minute', 'minutes', 'min', 'm']
@@ -29,10 +29,10 @@ def to_nparray(self, timeformat='h'):
     dayformat = ['day', 'days', 'd']
     yearformat = ['year', 'years', 'y']
 
-    rflux = np.array(self.fluxlike['flux'])  # flux (MJy/sr)                : [n_wavelengths x n_integrations]
-    rfluxe = np.array(self.fluxlike['uncertainty'])  # flux error (MJy/sr)  : [n_wavelengths x n_integrations]
-    rtime = np.array(self.timelike['time'])  # time (BJD_TDB, hours)        : [n_integrations]
-    rwavel = np.array(self.wavelike['wavelength'])  # wavelength (microns)  : [n_wavelengths]
+    rflux  = np.array(self.fluxlike['flux'])  # flux                         : [n_wavelengths x n_integrations]
+    rfluxu = np.array(self.fluxlike['uncertainty'])  # uncertainty           : [n_wavelengths x n_integrations]
+    rtime  = np.array(self.timelike['time'])  # time (BJD_TDB, hours)        : [n_integrations]
+    rwavel  = np.array(self.wavelike['wavelength'])  # wavelength (microns)  : [n_wavelengths]
 
     # change the time array into the requested format (e.g. seconds, minutes, days etc.)
     if timeformat in secondformat:
@@ -40,9 +40,9 @@ def to_nparray(self, timeformat='h'):
     elif timeformat in minuteformat:
         rtime = rtime * 60
     elif timeformat in hourformat:
-        # hours is the default time setting
         pass
     elif timeformat in dayformat:
+        # hours is the default time setting
         rtime = rtime / 24.
     elif timeformat in yearformat:
         rtime = rtime / (24 * 365.)
@@ -50,29 +50,29 @@ def to_nparray(self, timeformat='h'):
         warnings.warn("Unrecognised Time Format!")
         return
 
-    return rflux, rfluxe, rtime, rwavel
+    return rflux, rfluxu, rtime, rwavel
 
 
-def to_df(self, timeformat='h'):
+def to_df(self, timeformat='d'):
     """ Convert Rainbow object to pandas dataframe
     Parameters
     ----------
         self : Rainbow object
             chromatic Rainbow object to convert into pandas df format
         timeformat : str
-            (optional, default='hours')
+            (optional, default='d')
             The time format to use (seconds, minutes, hours, days etc.)
     Returns
     ----------
         pd.DataFrame
     """
     # extract 1D/2D formats for the flux, uncertainty, time and wavelengths
-    rflux, rfluxe, rtime, rwavel = self.to_nparray(timeformat)
+    rflux, rfluxu, rtime, rwavel = self.to_nparray(timeformat)
 
     # put all arrays onto same dimensions
     x, y = np.meshgrid(rtime, rwavel)
     rainbow_dict = {f"Time ({timeformat})": x.ravel(), "Wavelength (microns)": y.ravel(), "Flux": rflux.ravel(),
-                    "Flux Error": rfluxe.ravel()}
+                    "Flux Uncertainty": rfluxu.ravel()}
 
     # convert to pandas dataframe
     df = pd.DataFrame(rainbow_dict)

--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -661,6 +661,8 @@ class Rainbow:
         trim_nan_wavelengths,
         _create_shared_wavelength_axis,
         align_wavelengths,
+        to_nparray,
+        to_df,
     )
 
     # import summary statistics for each wavelength

--- a/chromatic/rainbows/simulated.py
+++ b/chromatic/rainbows/simulated.py
@@ -136,7 +136,7 @@ class SimulatedRainbow(Rainbow):
         else:
             t_unit = time.unit
 
-        self.timelike["time"] = u.Quantity(time)
+        self.timelike["time"] = u.Quantity(time).to(u.day)
         # TODO, make this match up better with astropy time
 
     def _setup_fake_wavelength_grid(
@@ -200,11 +200,8 @@ class SimulatedRainbow(Rainbow):
             w_unit = wavelength.unit
 
         # make sure the wavelength array has units
-        self.wavelike["wavelength"] = u.Quantity(wavelength)
+        self.wavelike["wavelength"] = u.Quantity(wavelength).to(u.micron)
         self._guess_wscale()
-
-        # this should break if the units aren't length
-        w_unit.to("m")
 
     def inject_transit(self, planet_params={}, planet_radius=0.1):
 

--- a/chromatic/tests/__init__.py
+++ b/chromatic/tests/__init__.py
@@ -8,3 +8,4 @@ from .test_rainbow_visualizations import *
 from .test_resampling import *
 from .test_units import *
 from .test_align_wavelengths import *
+from .test_conversions import *

--- a/chromatic/tests/test_conversions.py
+++ b/chromatic/tests/test_conversions.py
@@ -1,12 +1,11 @@
 from ..rainbows import *
 
+closekw = dict(rtol=1e-10)
+
 
 def test_to_df():
 
-    r = SimulatedRainbow(
-        signal_to_noise=10,
-        dt=1 * u.minute,
-        R=50)
+    r = SimulatedRainbow(signal_to_noise=10, dt=1 * u.minute, R=50)
 
     r_df = r.to_df()
 
@@ -15,32 +14,31 @@ def test_to_df():
 
     # ensure we have the right column names
     columnnames = r_df.columns
-    for colname in ['Time (d)', 'Wavelength (micron)', 'Flux', 'Flux Uncertainty']:
+    for colname in ["Time (d)", "Wavelength (micron)", "Flux", "Flux Uncertainty"]:
         assert colname in columnnames
 
     # check the values in the df match the rainbow
-    assert np.isclose(r_df['Time (d)'].values[0],r.time.to_value()[0] / 24.)  # default=days
-    assert r_df['Wavelength (micron)'].values[0] == r.wavelength.to_value()[0]
-    assert r_df['Flux'].values[0] == r.flux[0, 0]
-    assert r_df['Flux Uncertainty'].values[0] == r.uncertainty[0, 0]
+    assert np.isclose(
+        r_df["Time (d)"].values[0], r.time.to_value("h")[0] / 24.0, **closekw
+    )  # default=days
+    assert r_df["Wavelength (micron)"].values[0] == r.wavelength.to_value("micron")[0]
+    assert r_df["Flux"].values[0] == r.flux[0, 0]
+    assert r_df["Flux Uncertainty"].values[0] == r.uncertainty[0, 0]
 
     # test the timeformat parameter
-    for t_unit in ['h', 'hour', 'day', 'minute', 'second', 's']:
+    for t_unit in ["h", "hour", "day", "minute", "second", "s"]:
         r_df = r.to_df(t_unit=t_unit)
-        assert f'Time ({t_unit})' in r_df.columns
+        assert f"Time ({t_unit})" in r_df.columns
 
 
 def test_to_nparray():
-    r = SimulatedRainbow(
-        signal_to_noise=100,
-        dt=1 * u.minute,
-        R=50)
+    r = SimulatedRainbow(signal_to_noise=100, dt=1 * u.minute, R=50)
 
     rflux, rfluxu, rtime, rwavel = r.to_nparray()
 
     assert len(rtime) == r.ntime
     assert len(rwavel) == r.nwave
-    assert len(rtime)*len(rwavel) == r.nflux
+    assert len(rtime) * len(rwavel) == r.nflux
     assert len(rflux.flatten()) == r.nflux
     assert len(rfluxu.flatten()) == r.nflux
     assert np.shape(rflux) == r.shape
@@ -48,23 +46,21 @@ def test_to_nparray():
 
     assert np.all(rflux == r.flux)
     assert np.all(rfluxu == r.uncertainty)
-    assert np.all(rwavel == r.wavelength.to_value())
-    assert np.all(rwavel == r.wavelength.to_value())
+    assert np.all(rwavel == r.wavelength.to_value("micron"))
 
     # issues with rounding errors:
-    assert np.all(np.isclose(rtime, r.time.to_value()/24.))  # the default is days
+    assert np.all(
+        np.isclose(rtime, r.time.to_value("h") / 24.0, **closekw)
+    )  # the default is days
 
     # test if the hours format works
-    rflux, rfluxu, rtime, rwavel = r.to_nparray(t_unit='h')
-    assert np.all(rtime == r.time.to_value())
+    rflux, rfluxu, rtime, rwavel = r.to_nparray(t_unit="h")
+    assert np.all(np.isclose(rtime, r.time.to_value("h"), **closekw))
 
     # test if the minutes format works
-    rflux, rfluxu, rtime, rwavel = r.to_nparray(t_unit='min')
-    assert np.all(rtime == r.time.to_value()*60)
+    rflux, rfluxu, rtime, rwavel = r.to_nparray(t_unit="min")
+    assert np.all(np.isclose(rtime, r.time.to_value("h") * 60, **closekw))
 
     # test if the minutes format works
-    rflux, rfluxu, rtime, rwavel = r.to_nparray(t_unit='s')
-    assert np.all(rtime == r.time.to_value()*3600)
-
-
-
+    rflux, rfluxu, rtime, rwavel = r.to_nparray(t_unit="s")
+    assert np.all(np.isclose(rtime, r.time.to_value("h") * 3600, **closekw))

--- a/chromatic/tests/test_conversions.py
+++ b/chromatic/tests/test_conversions.py
@@ -15,19 +15,19 @@ def test_to_df():
 
     # ensure we have the right column names
     columnnames = r_df.columns
-    for colname in ['Time (d)', 'Wavelength (microns)', 'Flux', 'Flux Uncertainty']:
+    for colname in ['Time (d)', 'Wavelength (micron)', 'Flux', 'Flux Uncertainty']:
         assert colname in columnnames
 
     # check the values in the df match the rainbow
-    assert r_df['Time (d)'].values[0] == r.time.to_value()[0] / 24.  # default=days
-    assert r_df['Wavelength (microns)'].values[0] == r.wavelength.to_value()[0]
+    assert np.isclose(r_df['Time (d)'].values[0],r.time.to_value()[0] / 24.)  # default=days
+    assert r_df['Wavelength (micron)'].values[0] == r.wavelength.to_value()[0]
     assert r_df['Flux'].values[0] == r.flux[0, 0]
     assert r_df['Flux Uncertainty'].values[0] == r.uncertainty[0, 0]
 
     # test the timeformat parameter
-    for timeformat in ['h', 'hour', 'day', 'minute', 'second', 's']:
-        r_df = r.to_df(timeformat=timeformat)
-        assert f'Time ({timeformat})' in r_df.columns
+    for t_unit in ['h', 'hour', 'day', 'minute', 'second', 's']:
+        r_df = r.to_df(t_unit=t_unit)
+        assert f'Time ({t_unit})' in r_df.columns
 
 
 def test_to_nparray():
@@ -51,18 +51,19 @@ def test_to_nparray():
     assert np.all(rwavel == r.wavelength.to_value())
     assert np.all(rwavel == r.wavelength.to_value())
 
-    assert np.all(rtime == r.time.to_value()/24.)  # the default is days
+    # issues with rounding errors:
+    assert np.all(np.isclose(rtime, r.time.to_value()/24.))  # the default is days
 
     # test if the hours format works
-    rflux, rfluxu, rtime, rwavel = r.to_nparray(timeformat='h')
+    rflux, rfluxu, rtime, rwavel = r.to_nparray(t_unit='h')
     assert np.all(rtime == r.time.to_value())
 
     # test if the minutes format works
-    rflux, rfluxu, rtime, rwavel = r.to_nparray(timeformat='m')
+    rflux, rfluxu, rtime, rwavel = r.to_nparray(t_unit='min')
     assert np.all(rtime == r.time.to_value()*60)
 
     # test if the minutes format works
-    rflux, rfluxu, rtime, rwavel = r.to_nparray(timeformat='s')
+    rflux, rfluxu, rtime, rwavel = r.to_nparray(t_unit='s')
     assert np.all(rtime == r.time.to_value()*3600)
 
 

--- a/chromatic/tests/test_conversions.py
+++ b/chromatic/tests/test_conversions.py
@@ -1,0 +1,65 @@
+from ..rainbows import *
+
+
+def test_to_df():
+
+    r = SimulatedRainbow(
+        signal_to_noise=10,
+        dt=1 * u.minute,
+        R=50)
+
+    r_df = r.to_df()
+
+    # ensure the length of the df is the same as the original rainbow
+    assert len(r_df) == r.nflux
+
+    # ensure we have the right column names
+    columnnames = r_df.columns
+    for colname in ['Time (d)', 'Wavelength (microns)', 'Flux', 'Flux Uncertainty']:
+        assert colname in columnnames
+
+    # check the values in the df match the rainbow
+    assert r_df['Time (d)'].values[0] == r.time.to_value()[0] / 24.  # default=days
+    assert r_df['Wavelength (microns)'].values[0] == r.wavelength.to_value()[0]
+    assert r_df['Flux'].values[0] == r.flux[0, 0]
+    assert r_df['Flux Uncertainty'].values[0] == r.uncertainty[0, 0]
+
+    # test the timeformat parameter
+    for timeformat in ['h', 'hour', 'day', 'minute', 'second', 's']:
+        r_df = r.to_df(timeformat=timeformat)
+        assert f'Time ({timeformat})' in r_df.columns
+
+
+def test_to_nparray():
+    r = SimulatedRainbow(
+        signal_to_noise=100,
+        dt=1 * u.minute,
+        R=50)
+
+    rflux, rfluxu, rtime, rwavel = r.to_nparray()
+
+    assert len(rtime) == r.ntime
+    assert len(rwavel) == r.nwave
+    assert len(rtime)*len(rwavel) == r.nflux
+    assert len(rflux.flatten()) == r.nflux
+    assert len(rfluxu.flatten()) == r.nflux
+    assert np.shape(rflux) == r.shape
+    assert np.shape(rfluxu) == r.shape
+
+    assert np.all(rflux == r.flux)
+    assert np.all(rfluxu == r.uncertainty)
+    assert np.all(rwavel == r.wavelength.to_value())
+    assert np.all(rwavel == r.wavelength.to_value())
+
+    assert np.all(rtime == r.time.to_value()/24.)  # the default is days
+
+    # test if the hours format works
+    rflux, rfluxu, rtime, rwavel = r.to_nparray(timeformat='h')
+    assert np.all(rtime == r.time.to_value())
+
+    # test if the minutes format works
+    rflux, rfluxu, rtime, rwavel = r.to_nparray(timeformat='min')
+    assert np.all(rtime == r.time.to_value()*60)
+
+
+

--- a/chromatic/tests/test_conversions.py
+++ b/chromatic/tests/test_conversions.py
@@ -58,8 +58,12 @@ def test_to_nparray():
     assert np.all(rtime == r.time.to_value())
 
     # test if the minutes format works
-    rflux, rfluxu, rtime, rwavel = r.to_nparray(timeformat='min')
+    rflux, rfluxu, rtime, rwavel = r.to_nparray(timeformat='m')
     assert np.all(rtime == r.time.to_value()*60)
+
+    # test if the minutes format works
+    rflux, rfluxu, rtime, rwavel = r.to_nparray(timeformat='s')
+    assert np.all(rtime == r.time.to_value()*3600)
 
 
 

--- a/chromatic/version.py
+++ b/chromatic/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.23"
+__version__ = "0.0.24"
 
 
 def version():


### PR DESCRIPTION
Changes in this pull request:
- Added pandas to **import.py**
- Added 'conversions.py' in the **actions** dir which contains .to_nparray() and .to_df() which convert a rainbow object to numpy arrays and pandas dataframe respectively. This includes an optional _timeformat_ argument that allows the user to specify seconds, minutes, hours, days or years for the time argument (default=hours).
- Added these two methods to **actions/__init__.py**
- Added these two methods to the list of actions in **rainbow.py**
- Updated the version to v0.0.24