### PR TITLE
Add interactive plot

### DIFF
--- a/chromatic/rainbows/actions/conversions.py
+++ b/chromatic/rainbows/actions/conversions.py
@@ -3,76 +3,79 @@ from ...imports import *
 __all__ = ["to_nparray", "to_df"]
 
 
-def to_nparray(self, timeformat='h'):
+def to_nparray(self, t_unit='d', w_unit='micron'):
     """ Convert Rainbow object to 1D and 2D numpy arrays
     Parameters
     ----------
-        self : Rainbow object
-            chromatic Rainbow object to convert into array format
-        timeformat : str
-            (optional, default='hours')
-            The time format to use (seconds, minutes, hours, days etc.)
+    self : Rainbow object
+        chromatic Rainbow object to convert into array format
+    t_unit : str
+        (optional, default='d')
+        The time units to use (seconds, minutes, hours, days etc.)
+    w_unit : str
+        (optional, default='micron')
+        The wavelength units to use
     Returns
     ----------
-        rflux : np.array
-            flux (MJy/sr)        [n_wavelengths x n_integrations]
-        rfluxe : np.array
-            flux error (MJy/sr)  [n_wavelengths x n_integrations]
-        rtime : np.array
-            time (BJD_TDB, hours) [n_integrations]
-        rwavel : np.array
-            wavelength (microns) [n_wavelengths]
+    rflux : np.array
+        flux                   [n_wavelengths x n_integrations]
+    rfluxu : np.array
+        flux uncertainty       [n_wavelengths x n_integrations]
+    rtime : np.array
+        time (t_unit)          [n_integrations]
+    rwavel : np.array
+        wavelength (w_unit)    [n_wavelengths]
     """
-    secondformat = ['second', 'seconds', 'sec', 's']
-    minuteformat = ['minute', 'minutes', 'min', 'm']
-    hourformat = ['hour', 'hours', 'h']
-    dayformat = ['day', 'days', 'd']
-    yearformat = ['year', 'years', 'y']
 
-    rflux = np.array(self.fluxlike['flux'])  # flux (MJy/sr)                : [n_wavelengths x n_integrations]
-    rfluxe = np.array(self.fluxlike['uncertainty'])  # flux error (MJy/sr)  : [n_wavelengths x n_integrations]
-    rtime = np.array(self.timelike['time'])  # time (BJD_TDB, hours)        : [n_integrations]
-    rwavel = np.array(self.wavelike['wavelength'])  # wavelength (microns)  : [n_wavelengths]
+    rflux = np.array(self.fluxlike['flux'])  # flux                       : [n_wavelengths x n_integrations]
+    rfluxu = np.array(self.fluxlike['uncertainty'])  # uncertainty        : [n_wavelengths x n_integrations]
+    rtime = self.timelike['time']  # time (BJD_TDB, hours)                : [n_integrations]
+    rwavel = self.wavelike['wavelength']  # wavelength (microns)          : [n_wavelengths]
 
-    # change the time array into the requested format (e.g. seconds, minutes, days etc.)
-    if timeformat in secondformat:
-        rtime = rtime * 3600
-    elif timeformat in minuteformat:
-        rtime = rtime * 60
-    elif timeformat in hourformat:
-        # hours is the default time setting
-        pass
-    elif timeformat in dayformat:
-        rtime = rtime / 24.
-    elif timeformat in yearformat:
-        rtime = rtime / (24 * 365.)
-    else:
-        warnings.warn("Unrecognised Time Format!")
-        return
+    try:
+        # nice bit of code copied from .imshow(), thanks Zach!
+        # Change time into the units requested by the user
+        t_unit = u.Unit(t_unit)
+    except:
+        warnings.warn("Unrecognised Time Format! Returning day by default")
+        t_unit = u.Unit('d')
+    rtime = np.array((rtime / t_unit).decompose())
 
-    return rflux, rfluxe, rtime, rwavel
+    try:
+        # Change wavelength into the units requested by the user
+        w_unit = u.Unit(w_unit)
+    except:
+        warnings.warn("Unrecognised Wavelength Format! Returning micron by default")
+        w_unit = u.Unit('micron')
+    rwavel = np.array((rwavel / w_unit).decompose())
+
+    return rflux, rfluxu, rtime, rwavel
 
 
-def to_df(self, timeformat='h'):
+def to_df(self, t_unit='d', w_unit='micron'):
     """ Convert Rainbow object to pandas dataframe
     Parameters
     ----------
-        self : Rainbow object
-            chromatic Rainbow object to convert into pandas df format
-        timeformat : str
-            (optional, default='hours')
-            The time format to use (seconds, minutes, hours, days etc.)
+    self : Rainbow object
+        chromatic Rainbow object to convert into pandas df format
+    t_unit : str
+        (optional, default='d')
+         The time units to use (seconds, minutes, hours, days etc.)
+    w_unit : str
+        (optional, default='micron')
+        The wavelength units to use
     Returns
     ----------
-        pd.DataFrame
+    pd.DataFrame
+        The rainbow object flattened and converted into a pandas dataframe
     """
     # extract 1D/2D formats for the flux, uncertainty, time and wavelengths
-    rflux, rfluxe, rtime, rwavel = self.to_nparray(timeformat)
+    rflux, rfluxu, rtime, rwavel = self.to_nparray(t_unit=t_unit, w_unit=w_unit)
 
     # put all arrays onto same dimensions
     x, y = np.meshgrid(rtime, rwavel)
-    rainbow_dict = {f"Time ({timeformat})": x.ravel(), "Wavelength (microns)": y.ravel(), "Flux": rflux.ravel(),
-                    "Flux Error": rfluxe.ravel()}
+    rainbow_dict = {f"Time ({t_unit})": x.ravel(), f"Wavelength ({w_unit})": y.ravel(), "Flux": rflux.ravel(),
+                    "Flux Uncertainty": rfluxu.ravel()}
 
     # convert to pandas dataframe
     df = pd.DataFrame(rainbow_dict)

--- a/chromatic/rainbows/actions/conversions.py
+++ b/chromatic/rainbows/actions/conversions.py
@@ -19,7 +19,7 @@ def to_nparray(self, timeformat='h'):
         rfluxe : np.array
             flux error (MJy/sr)  [n_wavelengths x n_integrations]
         rtime : np.array
-            time (BJD_TDB, houra) [n_integrations]
+            time (BJD_TDB, hours) [n_integrations]
         rwavel : np.array
             wavelength (microns) [n_wavelengths]
     """

--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -686,4 +686,5 @@ class Rainbow:
         get_wavelength_color,
         imshow_quantities,
         plot_quantities,
+        imshow_interact,
     )

--- a/chromatic/rainbows/visualizations/__init__.py
+++ b/chromatic/rainbows/visualizations/__init__.py
@@ -3,3 +3,4 @@ from .imshow import *
 from .plot import *
 from .animate import *
 from .diagnostics import *
+from .interactive import *

--- a/chromatic/rainbows/visualizations/interactive.py
+++ b/chromatic/rainbows/visualizations/interactive.py
@@ -1,0 +1,115 @@
+from ...imports import *
+
+# don't make Altair a necessary part of chromatic
+try:
+    import altair as alt
+    alt.data_transformers.disable_max_rows()
+except Exception as e:
+    print(e)
+    warnings.warn("Issue importing Altair, cannot make interactive plot :(!")
+
+__all__ = ["imshow_interact"]
+
+
+# Convert this grid to columnar data expected by Altair
+def imshow_interact(self, quantity='Flux', ylog=False, timeformat='h'):
+    """ Display interactive spectrum plot for chromatic Rainbow with a wavelength-averaged 2D quantity
+    defined by the user. The user can interact with the 3D spectrum to choose the wavelength range over
+    which the average is calculated.
+
+    Parameters
+    ----------
+        self : Rainbow object
+            chromatic Rainbow object to plot
+        quantity : str
+            (optional, default='Flux)
+            The quantity on the z-axis
+        ylog : boolean
+            (optional, default=False)
+            Boolean for whether to take log10 of the y-axis data
+        timeformat : str
+            (optional, default='hours')
+            The time format to use (seconds, minutes, hours, days etc.)
+    """
+
+    # preset the x and y axes as Time (in units defined by the user) and Wavelength
+    xlabel = f"Time ({timeformat})"
+    ylabel = "Wavelength (microns)"
+
+    # allow the user to plot flux or uncertainty
+    if quantity.lower() == "flux":
+        z = "Flux"
+    elif quantity.lower() == "uncertainty":
+        z = "Flux Error"
+    elif quantity.lower() == "error":
+        z = "Flux Error"
+    elif quantity.lower() == "flux_error":
+        z = "Flux Error"
+    else:
+        # if the quantity is not one of the predefined values:
+        warnings.warn("Unrecognised Quantity!")
+        return
+
+    # convert rainbow object to pandas dataframe
+    source = self.to_df(timeformat=timeformat)[[xlabel, ylabel, z]]
+
+    # if there are >10,000 data points Altair will be very laggy/slow. This is probably unbinned, therefore
+    # encourage the user to bin the Rainbow before calling this function in future/
+    if len(source) > 10000:
+        warnings.warn(">10,000 data points - interactive plot will lag! You should try binning the Rainbow first!")
+        if not ylog:
+            warnings.warn("It looks like you might have unbinned data - you may want to use ylog=True!")
+
+    # The unbinned Rainbow is sometimes in log scale, therefore plotting will be ugly with uniform axis spacing
+    # ylog tells the function to bin the y-axis data
+    if ylog:
+        source[ylabel] = np.log10(source[ylabel])
+        source = source.rename(columns={ylabel: f"log({ylabel})"})
+        ylabel = f"log({ylabel})"
+
+    # Add interactive part
+    brush = alt.selection(type='interval', encodings=['y'])
+
+    # Define the 3D spectrum plot
+    spectrum = alt.Chart(source, width=280, height=230).mark_rect(clip=False, width=280 / len(self.timelike['time']),
+                                                                  height=230 / len(self.wavelike['wavelength'])).encode(
+        x=alt.X(f'{xlabel}:Q', scale=alt.Scale(zero=False, nice=False, domain=[np.min(source[xlabel]),
+                                                                               np.max(source[xlabel])])),
+        y=alt.Y(f'{ylabel}:Q', scale=alt.Scale(zero=False, nice=False, domain=[np.max(source[ylabel]),
+                                                                               np.min(source[ylabel])])),
+        fill=alt.Color(f'{z}:Q', scale=alt.Scale(scheme='viridis', zero=False, domain=[np.min(source[z]),
+                                                                                       np.max(source[z])])),
+        tooltip=[f'{xlabel}', f'{ylabel}', f'{z}']
+    )
+
+    # gray out the background with selection
+    background = spectrum.encode(
+        color=alt.value('#ddd')
+    ).add_selection(brush)
+
+    # highlights on the transformed data
+    highlight = spectrum.transform_filter(brush)
+
+    # Layer the various plotting parts
+    spectrum_int = alt.layer(
+        background,
+        highlight,
+        data=source
+    )
+
+    # Add the 2D averaged lightcurve (or uncertainty)
+    lightcurve = alt.Chart(source, width=280, height=230, title=f"Mean {z} for Wavelength Range").mark_point(
+        filled=True, size=20, color='black').encode(
+        x=alt.X(f'{xlabel}:Q',
+                scale=alt.Scale(zero=False, nice=False,
+                                domain=[np.min(source[xlabel]) - (0.02 * np.abs(np.min(source[xlabel]))),
+                                        1.02 * np.max(source[xlabel])])),
+        y=alt.Y(f'mean({z}):Q',
+                scale=alt.Scale(zero=False, domain=[np.mean(source[z]).min() - 0.01, np.mean(source[z]).max() + 0.01]),
+                title='Mean ' + z)
+    ).transform_filter(
+        brush
+    )
+
+    # display the interactive Altair plot
+    (spectrum_int | lightcurve).display()

--- a/chromatic/rainbows/visualizations/interactive.py
+++ b/chromatic/rainbows/visualizations/interactive.py
@@ -61,7 +61,7 @@ def imshow_interact(self, quantity='Flux', ylog=False, timeformat='h'):
             warnings.warn("It looks like you might have unbinned data - you may want to use ylog=True!")
 
     # The unbinned Rainbow is sometimes in log scale, therefore plotting will be ugly with uniform axis spacing
-    # ylog tells the function to bin the y-axis data
+    # ylog tells the function to take the log10 of the y-axis data
     if ylog:
         source[ylabel] = np.log10(source[ylabel])
         source = source.rename(columns={ylabel: f"log({ylabel})"})

--- a/chromatic/tests/test_rainbow_visualizations.py
+++ b/chromatic/tests/test_rainbow_visualizations.py
@@ -87,3 +87,8 @@ def test_wavelength_cmap():
     # test a few examples
     assert r.get_wavelength_color(r.wavelength[0]) == (0.0, 0.0, 0.0, 1.0)
     assert r.get_wavelength_color(r.wavelength[-1]) == (1.0, 0.0, 0.0, 1.0)
+
+
+def test_imshow_interact():
+    plt.figure()
+    SimulatedRainbow(R=10).imshow_interact()

--- a/chromatic/version.py
+++ b/chromatic/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.24"
+__version__ = "0.0.25"
 
 
 def version():

--- a/docs/visualizing.ipynb
+++ b/docs/visualizing.ipynb
@@ -261,8 +261,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "r.imshow_interact(cmap='magma', t_unit='h')"
+    "r.imshow_interact(cmap='magma', t_unit='h', w_unit='nm', custom_ylims=[0.97,1.01])"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also plot the uncertainty, though in this simulated case it is time and wavelength-independent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.imshow_interact(quantity='uncertainty')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/visualizing.ipynb
+++ b/docs/visualizing.ipynb
@@ -234,9 +234,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This feature requires [Altair](https://altair-viz.github.io/getting_started/installation.html) to be installed.\n",
+    "*This feature requires [Altair](https://altair-viz.github.io/getting_started/installation.html). It should already be installed as a dependency for `chromatic-lightcurves`, but you might need to install it yourself.*\n",
     "\n",
-    "Similar to .imshow() but you can select a wavelength range on the spectrum to generate a wavelength-averaged lightcurve from your selection. "
+    "Similar to `.imshow()` but you can click and drag on the `imshow` panel on the left to select a wavelength range for generating a wavelength-averaged lightcurve. "
    ]
   },
   {
@@ -252,7 +252,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Similarly to imshow() there are options you might like to change (see [Vega documentation](https://vega.github.io/vega/docs/schemes/) for color schemes):"
+    "Like `imshow()`, there are options you might like to change (see [Vega documentation](https://vega.github.io/vega/docs/schemes/) for color schemes):"
    ]
   },
   {
@@ -268,7 +268,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also plot the uncertainty, though in this simulated case it is time and wavelength-independent"
+    "We can also plot the `uncertainty` (or any other fluxlike quantity). In this simulated case, it is time and wavelength-independent so not very interesting."
    ]
   },
   {
@@ -279,18 +279,11 @@
    "source": [
     "r.imshow_interact(quantity='uncertainty')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/docs/visualizing.ipynb
+++ b/docs/visualizing.ipynb
@@ -222,6 +222,47 @@
    "source": [
     "<img src='animated-spectra.gif' align='left'>"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 🌈.imshow_interact()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This feature requires [Altair](https://altair-viz.github.io/getting_started/installation.html) to be installed.\n",
+    "\n",
+    "Similar to .imshow() but you can select a wavelength range on the spectrum to generate a wavelength-averaged lightcurve from your selection. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.imshow_interact()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similarly to imshow() there are options you might like to change (see [Vega documentation](https://vega.github.io/vega/docs/schemes/) for color schemes):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.imshow_interact(cmap='magma', t_unit='h')"
+   ]
   }
  ],
  "metadata": {
@@ -240,7 +281,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ setup(
             "mkdocs-exclude",
             "twine",
         ],
+        "interact": ["altair"],
         "cartoons": ["rainbow-connection>=0.0.7"],
     },
     # (I think just leave this set to False)

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
         "astropy>=4.0",
         "tqdm",
         "batman-package",
+        "altair",
     ],
     # what version of Python is required?
     python_requires=">=3.6",  # f-strings are introduced in 3.6!
@@ -104,7 +105,6 @@ setup(
             "mkdocs-exclude",
             "twine",
         ],
-        "interact": ["altair"],
         "cartoons": ["rainbow-connection>=0.0.7"],
     },
     # (I think just leave this set to False)


### PR DESCRIPTION
This relies on the .to_df() and .to_nparray() methods in my previous pull request!!
 (not quite sure how that works with the git pull/merge - I think making this pull request would make my previous one redundant?)

Changes in this pull request:
- Added **visualizations/interactive.py** containing the altair code to generate and display an interactive wavelength-averaged plot (I kept _import altair_ out of imports for now). This has the argument _quantity_ which allows the user to also plot the uncertainty
- Added _imshow_interact_ to the **visualizations/__init__.py**
- Added _imshow_interact_ to the **rainbow.py** plotting actions
- Updated version to v0.0.25

Basic usage:
For unbinned data (will throw a warning because it will work but it's slow, also demonstrates the use of the _ylog_ argument):
![Screenshot 2022-05-26 at 14 40 11](https://user-images.githubusercontent.com/34891147/170577246-e63a4b10-ea38-453f-9297-adafb68f2adc.png)
For binned data (demonstrating changing the _timeformat_ argument to days)
![Screenshot 2022-05-26 at 14 40 44](https://user-images.githubusercontent.com/34891147/170577269-b19bc6d2-97f8-48e4-8bf3-c5956eca8b2a.png)

