### PR TITLE
Add ability to say `r.time = ...` (and other quantities too).

### DIFF
--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -394,12 +394,26 @@ class Rainbow:
         """
         return self.wavelike.get("wavelength", None)
 
-    @property
-    def time(self):
+    @wavelength.setter
+    def wavelength(self, value):
         """
         The 1D array of wavelengths (with astropy units of length).
         """
+        self.wavelike["wavelength"] = value
+
+    @property
+    def time(self):
+        """
+        The 1D array of time (with astropy units of time).
+        """
         return self.timelike.get("time", None)
+
+    @time.setter
+    def time(self, value):
+        """
+        The 1D array of time (with astropy units of time).
+        """
+        self.timelike["time"] = value
 
     @property
     def flux(self):
@@ -408,6 +422,13 @@ class Rainbow:
         """
         return self.fluxlike.get("flux", None)
 
+    @flux.setter
+    def flux(self, value):
+        """
+        The 2D array of fluxes (row = wavelength, col = time).
+        """
+        self.fluxlike["flux"] = value
+
     @property
     def uncertainty(self):
         """
@@ -415,12 +436,26 @@ class Rainbow:
         """
         return self.fluxlike.get("uncertainty", None)
 
+    @uncertainty.setter
+    def uncertainty(self, value):
+        """
+        The 2D array of uncertainties on the fluxes.
+        """
+        self.fluxlike["uncertainty"] = value
+
     @property
     def ok(self):
         """
         The 2D array of whether data is OK (row = wavelength, col = time).
         """
         return self.fluxlike.get("ok", np.ones_like(self.flux).astype(bool))
+
+    @ok.setter
+    def ok(self, value):
+        """
+        The 2D array of whether data is OK (row = wavelength, col = time).
+        """
+        self.fluxlike["ok"] = value
 
     def __getattr__(self, key):
         """

--- a/chromatic/tests/setup_tests.py
+++ b/chromatic/tests/setup_tests.py
@@ -1,4 +1,4 @@
-import os
+import os, pytest
 
 test_directory = "examples/"
 

--- a/chromatic/tests/test_rainbow_basics.py
+++ b/chromatic/tests/test_rainbow_basics.py
@@ -81,5 +81,27 @@ def test_automatic_quantity_sorting():
     r.weird + 1
 
 
+def test_shape_warnings():
+    a = SimulatedRainbow()
+    with pytest.warns(match="transpose"):
+        a.flux = a.flux.T
+
+    b = SimulatedRainbow()
+    with pytest.warns(match="shape"):
+        b.wavelength = np.arange(b.nwave + 1)
+
+    c = SimulatedRainbow()
+    with pytest.warns(match="shape"):
+        c.time = np.arange(c.ntime + 1)
+
+    d = SimulatedRainbow()
+    with pytest.warns(match="shape"):
+        d.uncertainty = np.ones((d.nwave + 1, d.ntime + 1))
+
+    e = SimulatedRainbow()
+    with pytest.warns(match="shape"):
+        d.ok = np.ones((d.nwave + 1, d.ntime + 1))
+
+
 def test_help():
     Rainbow().help()

--- a/chromatic/tests/test_rainbow_basics.py
+++ b/chromatic/tests/test_rainbow_basics.py
@@ -60,5 +60,26 @@ def test_essential_properties():
     assert np.all(r.ok == False)
 
 
+def test_automatic_quantity_sorting():
+    # create a simulated rainbow
+    r = SimulatedRainbow()
+
+    # does a wavelength-shaped array end up in the right spot?
+    r.background = np.random.normal(10, 1, r.nwave)
+    assert "background" in r.wavelike
+
+    # does a time-shaped array end up in the right spot?
+    r.temperature = np.random.normal(10, 1, r.ntime)
+    assert "temperature" in r.timelike
+
+    # does a fluxes-shaped array end up in the right spot?
+    r.saturated = np.random.normal(0, 1, r.shape) > 2
+    assert "saturated" in r.fluxlike
+
+    # does a weirdly-shaped array still get assigned somewhere?
+    r.weird = np.random.normal(0, 1, (1, 2, 3, 4))
+    r.weird + 1
+
+
 def test_help():
     Rainbow().help()

--- a/chromatic/tests/test_rainbow_basics.py
+++ b/chromatic/tests/test_rainbow_basics.py
@@ -31,5 +31,34 @@ def test_rainbow_basics():
     )
 
 
+def test_essential_properties():
+    # create a simulated rainbow
+    r = SimulatedRainbow()
+
+    # wavelength
+    x = r.wavelength
+    r.wavelength = x * 2
+    assert np.all(r.wavelength == x * 2)
+
+    # time
+    x = r.time
+    r.time = x * 2
+    assert np.all(r.time == x * 2)
+
+    # flux
+    x = r.flux
+    r.flux = x * 2
+    assert np.all(r.flux == x * 2)
+
+    # uncertainty
+    x = r.uncertainty
+    r.uncertainty = x * 2
+    assert np.all(r.uncertainty == x * 2)
+
+    # ok
+    r.ok = np.isfinite(r.flux) == False
+    assert np.all(r.ok == False)
+
+
 def test_help():
     Rainbow().help()

--- a/docs/creating.ipynb
+++ b/docs/creating.ipynb
@@ -330,7 +330,7 @@
    "id": "86307081",
    "metadata": {},
    "source": [
-    "You can also add arrays directly to the core dictionaries:"
+    "You can also add arrays directly to a core dictionary by (a) providing a key and an array with the right shape or (b) setting an attribute with an array that would fit in one of the `timelike`, `wavelike`, or `fluxlike` dictionaries. The latter option will try to guess where an array belongs based on its shape, which should *mostly* work. The following two methods should be identical:"
    ]
   },
   {
@@ -340,7 +340,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "r.timelike['detector-temperature'] = np.random.normal(77, 0.3, N_wavelengths)"
+    "my_imaginary_temperatures = np.random.normal(77, 0.3, N_times)\n",
+    "r.timelike['detector_temperature'] = my_imaginary_temperatures\n",
+    "r.detector_temperature = my_imaginary_temperatures"
    ]
   },
   {


### PR DESCRIPTION
This Pull Request changes how the data are retrieved from and set in the core dictionaries. The key changes are as follows:
- Before this, you couldn't say something like `r.time = ...`, because the time "property" only retrieved data from the `r.timelike['time']` and could not change values in that dictionary. Now, saying `r.time = ...` will work and will store whatever quantities get assigned into the `.timelike['time']` array. The affected properties include `time`, `wavelength`, `flux`, `uncertainty`, and `ok`.
- Before this, you had to explicitly add auxiliary arrays to the appropriate dictionaries. Let's say you had an array of detector temperature as a function of time; the only way to store it with other timelike quantities would be to say `r.timelike['detector_temperature'] = ...`. Now, you can say `r.detector_temperature = ...`, and chromatic will try (usually pretty accurately!) to guess into which core dictionary the array should be stored, based on its shape.