### PR TITLE
Improve the `MultiRainbow` interface.

### DIFF
--- a/chromatic/rainbows/actions/__init__.py
+++ b/chromatic/rainbows/actions/__init__.py
@@ -4,3 +4,4 @@ from .normalization import *
 from .align_wavelengths import *
 from .conversions import *
 from .inject_transit import *
+from .fold import *

--- a/chromatic/rainbows/actions/__init__.py
+++ b/chromatic/rainbows/actions/__init__.py
@@ -5,3 +5,4 @@ from .align_wavelengths import *
 from .conversions import *
 from .inject_transit import *
 from .fold import *
+from .compare import *

--- a/chromatic/rainbows/actions/compare.py
+++ b/chromatic/rainbows/actions/compare.py
@@ -1,0 +1,20 @@
+from ...imports import *
+from ..multi import *
+
+
+def compare(self, rainbows):
+    """
+    Compare this Rainbow to others.
+
+    Parameters
+    ----------
+    rainbows : list
+        A list containing one or more other Rainbow objects.
+        If you only want to compare with one other Rainbow,
+        supply it in a 1-element list like `.compare([other])`
+    """
+    try:
+        rainbows.remove(self)
+    except (ValueError, IndexError):
+        pass
+    return compare_rainbows([self] + rainbows)

--- a/chromatic/rainbows/actions/descriptions.txt
+++ b/chromatic/rainbows/actions/descriptions.txt
@@ -4,7 +4,8 @@ cartoon | name | description
 🌈🍱💇 | trim | Trim away wavelengths or times that contain no good data.
 🌈🚧🌊 | align_wavelengths | Align spectra with different wavelength grids onto one shared axis.
 🌈🪐🚞 | inject_transit | Inject a transit signal into all wavelengths.
-🌈🎞⏲ | fold | Fold times relative to a particular period and epoch.
+🌈⏲🎞 | fold | Fold times relative to a particular period and epoch.
+🌈🧑‍🤝‍🧑🌈 | compare | Connect to other 🌈 objects for easy comparison.
 🌈🧮📝 | + | Add two Rainbows together.
 🌈🧮📝 | - | Subtract one Rainbows from another.
 🌈🧮📝 | * | Multiply two Rainbows together.

--- a/chromatic/rainbows/actions/descriptions.txt
+++ b/chromatic/rainbows/actions/descriptions.txt
@@ -4,6 +4,7 @@ cartoon | name | description
 🌈🍱💇 | trim | Trim away wavelengths or times that contain no good data.
 🌈🚧🌊 | align_wavelengths | Align spectra with different wavelength grids onto one shared axis.
 🌈🪐🚞 | inject_transit | Inject a transit signal into all wavelengths.
+🌈🎞⏲ | fold | Fold times relative to a particular period and epoch.
 🌈🧮📝 | + | Add two Rainbows together.
 🌈🧮📝 | - | Subtract one Rainbows from another.
 🌈🧮📝 | * | Multiply two Rainbows together.

--- a/chromatic/rainbows/actions/fold.py
+++ b/chromatic/rainbows/actions/fold.py
@@ -1,0 +1,46 @@
+from ...imports import *
+
+
+def fold(self, period=None, t0=None):
+    """
+    Fold this Rainbow to a period and reference epoch.
+
+    Parameters
+    ----------
+    period : u.Quantity
+        The orbital period of the planet (with astropy units of time)
+    t0 : u.Quantity
+        Any mid-transit epoch (with astropy units of time)
+
+    Returns
+    -------
+    folded : Rainbow
+        The folded Rainbow
+    """
+
+    # create a history entry for this action (before other variables are defined)
+    h = self._create_history_entry("fold", locals())
+
+    # warn
+    if (period is None) or (t0 is None):
+        message = """
+        Folding to a transit period requires both
+        `period` and `t0` be specified. Please try again.
+        """
+        warnings.warn(message)
+        return self
+
+    # create a copy of the existing rainbow
+    new = self._create_copy()
+
+    # calculate predicted time from transit
+    new.time = (((self.time - t0) + 0.5 * period) % period) - 0.5 * period
+    # (the nudge by 0.5 period is to center on -period/2 to period/2)
+
+    # change the default time label
+    new.metadata["time_label"] = "Time from Mid-Transit"
+
+    # append the history entry to the new Rainbow
+    new._record_history_entry(h)
+
+    return new

--- a/chromatic/rainbows/actions/normalization.py
+++ b/chromatic/rainbows/actions/normalization.py
@@ -23,8 +23,8 @@ def normalize(self, axis="wavelength", percentile=50):
 
     Returns
     -------
-    normalized : MultiRainbow
-        The normalized MultiRainbow.
+    normalized : Rainbow
+        The normalized Rainbow.
     """
 
     # create a history entry for this action (before other variables are defined)

--- a/chromatic/rainbows/actions/operations.py
+++ b/chromatic/rainbows/actions/operations.py
@@ -248,6 +248,9 @@ def __eq__(self, other):
     # start by assuming the Rainbows are identical
     same = True
 
+    if type(self) != type(other):
+        return False
+
     # loop through the core dictionaries
     for d in self._core_dictionaries:
 

--- a/chromatic/rainbows/actions/operations.py
+++ b/chromatic/rainbows/actions/operations.py
@@ -248,9 +248,6 @@ def __eq__(self, other):
     # start by assuming the Rainbows are identical
     same = True
 
-    if type(self) != type(other):
-        return False
-
     # loop through the core dictionaries
     for d in self._core_dictionaries:
 

--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -810,6 +810,7 @@ class Rainbow:
         align_wavelengths,
         inject_transit,
         fold,
+        compare,
         to_nparray,
         to_df,
     )

--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -211,8 +211,8 @@ class Rainbow:
                 self.timelike[k] = self.timelike[k][i_time]
         for k in self.fluxlike:
             if self.fluxlike[k] is not None:
-                self.fluxlike[k][:, :] = self.fluxlike[k][i_wavelength, :]
-                self.fluxlike[k][:, :] = self.fluxlike[k][:, i_time]
+                wave_sorted = self.fluxlike[k][i_wavelength, :]
+                self.fluxlike[k][:, :] = wave_sorted[:, i_time]
 
     def _validate_uncertainties(self):
         """

--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -505,6 +505,14 @@ class Rainbow:
         """
         return self.fluxlike.get("ok", np.ones_like(self.flux).astype(bool))
 
+    @property
+    def _time_label(self):
+        return self.metadata.get("time_label", "Time")
+
+    @property
+    def _wave_label(self):
+        return self.metadata.get("wave_label", "Wavelength")
+
     def __getattr__(self, key):
         """
         If an attribute/method isn't explicitly defined,
@@ -793,6 +801,7 @@ class Rainbow:
         _create_shared_wavelength_axis,
         align_wavelengths,
         inject_transit,
+        fold,
         to_nparray,
         to_df,
     )

--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -33,6 +33,7 @@ class Rainbow:
         timelike=None,
         fluxlike=None,
         metadata=None,
+        name=None,
         **kw,
     ):
         """
@@ -153,6 +154,9 @@ class Rainbow:
         # append the history entry to this Rainbow
         self._setup_history()
         self._record_history_entry(h)
+
+        # record the name of this Rainbow somewhere
+        self.metadata["name"] = name
 
     def _sort(self):
         """
@@ -569,6 +573,8 @@ class Rainbow:
             elif key in ["flux", "uncertainty", "ok"]:
                 self.fluxlike[key] = value
                 self._validate_core_dictionaries()
+            elif isinstance(value, str):
+                self.metadata[key] = value
             else:
                 self._put_array_in_right_dictionary(key, value)
         except ValueError:
@@ -743,6 +749,8 @@ class Rainbow:
         How should this object be represented as a string?
         """
         n = self.__class__.__name__.replace("Rainbow", "🌈")
+        if self.name is not None:
+            n += f"'{self.name}'"
         return f"<{n}({self.nwave}w, {self.ntime}t)>"
 
     def help(self, categories=["actions", "visualizations", "wavelike_summaries"]):

--- a/chromatic/rainbows/readers/schlawin.py
+++ b/chromatic/rainbows/readers/schlawin.py
@@ -22,11 +22,11 @@ def from_schlawin(rainbow, filepath):
     hdu_list = fits.open(filepath)
 
     # populate a 1D array of wavelengths (with astropy units of length)
-    rainbow.wavelike["indices"] = hdu_list["disp indices"].data
-    rainbow.wavelike["wavelength"] = hdu_list["wavelength"].data * u.micron
+    rainbow.wavelike["indices"] = hdu_list["disp indices"].data * 1
+    rainbow.wavelike["wavelength"] = hdu_list["wavelength"].data * u.micron * 1
 
     # populate a 1D array of times (with astropy units of time)
-    rainbow.timelike["time"] = hdu_list["time"].data * u.day
+    rainbow.timelike["time"] = hdu_list["time"].data * u.day * 1
 
     # populate a 2D (row = wavelength, col = array of fluxes
     for k in [
@@ -37,9 +37,9 @@ def from_schlawin(rainbow, filepath):
         "background spec",
         "refpix",
     ]:
-        rainbow.fluxlike[k] = hdu_list[k].data.T.squeeze()
-    rainbow.fluxlike["flux"] = rainbow.fluxlike["optimal spec"]
-    rainbow.fluxlike["uncertainty"] = rainbow.fluxlike["opt spec err"]
+        rainbow.fluxlike[k] = hdu_list[k].data.T.squeeze() * 1
+    rainbow.fluxlike["flux"] = rainbow.fluxlike["optimal spec"] * 1
+    rainbow.fluxlike["uncertainty"] = rainbow.fluxlike["opt spec err"] * 1
 
     # kludgily pull all extension headers into the metadata
     for k in hdu_list:

--- a/chromatic/rainbows/simulated.py
+++ b/chromatic/rainbows/simulated.py
@@ -13,6 +13,7 @@ class SimulatedRainbow(Rainbow):
         dw=None,
         wavelength=None,
         star_flux=None,
+        name=None,
     ):
         """
         Create a simulated rainbow object.
@@ -109,6 +110,7 @@ class SimulatedRainbow(Rainbow):
 
         # append the history entry to the new Rainbow
         self._record_history_entry(h)
+        self.metadata["name"] = name
 
     def _setup_fake_time_grid(
         self, tlim=[-2.5 * u.hour, 2.5 * u.hour], dt=1 * u.minute, time=None

--- a/chromatic/rainbows/visualizations/animate.py
+++ b/chromatic/rainbows/visualizations/animate.py
@@ -108,7 +108,9 @@ def _setup_animate_lightcurves(
             ylim[1] or 1.005 * np.nanmax(self.flux),
         )
         # set the axis labels
-        ax.set_xlabel(f"Time ({self.time.unit.to_string('latex_inline')})")
+        ax.set_xlabel(
+            f"{self._time_label} ({self.time.unit.to_string('latex_inline')})"
+        )
         ax.set_ylabel(f"Relative Flux")
 
         # guess a good number of digits to round
@@ -269,7 +271,9 @@ def _setup_animate_spectra(
             ylim[1] or 1.005 * np.nanmax(self.flux),
         )
         # set the axis labels
-        ax.set_xlabel(f"Wavelength ({self.wavelength.unit.to_string('latex_inline')})")
+        ax.set_xlabel(
+            f"{self._wave_label}  ({self.wavelength.unit.to_string('latex_inline')})"
+        )
         ax.set_ylabel(f"Relative Flux")
 
         # guess a good number of digits to round

--- a/chromatic/rainbows/visualizations/diagnostics/spectral_resolution.py
+++ b/chromatic/rainbows/visualizations/diagnostics/spectral_resolution.py
@@ -56,4 +56,6 @@ def plot_spectral_resolution(
         plt.ylabel(f"$R=\lambda/d\lambda$ ({pixels_per_resolution_element} pixel)")
         return ax
 
-        ax.set_xlabel(f"Time ({self.time.unit.to_string('latex_inline')})")
+        ax.set_xlabel(
+            f"{self._time_label} ({self.time.unit.to_string('latex_inline')})"
+        )

--- a/chromatic/rainbows/visualizations/imshow.py
+++ b/chromatic/rainbows/visualizations/imshow.py
@@ -43,13 +43,15 @@ def imshow(
 
     if self.wscale == "linear":
         wmin, wmax = self.wavelength[[0, -1]].to_value(w_unit)
-        ylabel = f"Wavelength ({w_unit.to_string('latex_inline')})"
+        ylabel = f"{self._wave_label} ({w_unit.to_string('latex_inline')})"
     elif self.wscale == "log":
         wmin, wmax = (
             np.log10(self.wavelength[0].to_value(w_unit)),
             np.log10(self.wavelength[-1].to_value(w_unit)),
         )
-        ylabel = r"log$_{10}$" + f"[Wavelength/({w_unit.to_string('latex_inline')})]"
+        ylabel = (
+            r"log$_{10}$" + f"[{self._wave_label}/({w_unit.to_string('latex_inline')})]"
+        )
     else:
         message = f"""
         The wavelength scale for this rainbow is '{self.wscale}'.
@@ -82,7 +84,7 @@ def imshow(
             **imshow_kw,
         )
         plt.ylabel(ylabel)
-        plt.xlabel(f"Time ({t_unit.to_string('latex_inline')})")
+        plt.xlabel(f"{self._time_label} ({t_unit.to_string('latex_inline')})")
         if colorbar:
             plt.colorbar(
                 ax=ax,

--- a/chromatic/rainbows/visualizations/imshow.py
+++ b/chromatic/rainbows/visualizations/imshow.py
@@ -69,7 +69,7 @@ def imshow(
         wmin, wmax = -0.5, self.nwave - 0.5
         ylabel = "Wavelength Index"
 
-    extent = [tmin, tmax, wmax, wmin]
+    self._imshow_extent = [tmin, tmax, wmax, wmin]
 
     # define some default keywords
     imshow_kw = dict(interpolation="nearest")
@@ -78,7 +78,7 @@ def imshow(
         plt.sca(ax)
         plt.imshow(
             self.fluxlike[quantity],
-            extent=extent,
+            extent=self._imshow_extent,
             aspect=aspect,
             origin="upper",
             **imshow_kw,

--- a/chromatic/rainbows/visualizations/imshow.py
+++ b/chromatic/rainbows/visualizations/imshow.py
@@ -39,24 +39,17 @@ def imshow(
 
     w_unit, t_unit = u.Unit(w_unit), u.Unit(t_unit)
 
-    if self.wscale == "linear":
-        extent = [
-            self.time[0].to_value(t_unit),
-            self.time[-1].to_value(t_unit),
-            self.wavelength[0].to_value(w_unit),
-            self.wavelength[-1].to_value(w_unit),
-        ]
-        ylabel = f"Wavelength ({w_unit.to_string('latex_inline')})"
+    tmin, tmax = self.time[[0, -1]].to_value(t_unit)
 
+    if self.wscale == "linear":
+        wmin, wmax = self.wavelength[[0, -1]].to_value(w_unit)
+        ylabel = f"Wavelength ({w_unit.to_string('latex_inline')})"
     elif self.wscale == "log":
-        extent = [
-            self.time[0].to_value(t_unit),
-            self.time[-1].to_value(t_unit),
+        wmin, wmax = (
             np.log10(self.wavelength[0].to_value(w_unit)),
             np.log10(self.wavelength[-1].to_value(w_unit)),
-        ]
+        )
         ylabel = r"log$_{10}$" + f"[Wavelength/({w_unit.to_string('latex_inline')})]"
-
     else:
         message = f"""
         The wavelength scale for this rainbow is '{self.wscale}'.
@@ -71,13 +64,10 @@ def imshow(
         `rainbow.bin(dw=...)` (for linear wavelengths)
         """
         warnings.warn(message)
-        extent = [
-            self.time[0].to_value(t_unit),
-            self.time[-1].to_value(t_unit),
-            self.nwave,
-            0,
-        ]
+        wmin, wmax = -0.5, self.nwave - 0.5
         ylabel = "Wavelength Index"
+
+    extent = [tmin, tmax, wmax, wmin]
 
     # define some default keywords
     imshow_kw = dict(interpolation="nearest")

--- a/chromatic/rainbows/visualizations/imshow.py
+++ b/chromatic/rainbows/visualizations/imshow.py
@@ -41,19 +41,19 @@ def imshow(
 
     if self.wscale == "linear":
         extent = [
-            (min(self.time) / t_unit).decompose(),
-            (max(self.time) / t_unit).decompose(),
-            (max(self.wavelength) / w_unit).decompose(),
-            (min(self.wavelength) / w_unit).decompose(),
+            self.time[0].to_value(t_unit),
+            self.time[-1].to_value(t_unit),
+            self.wavelength[0].to_value(w_unit),
+            self.wavelength[-1].to_value(w_unit),
         ]
         ylabel = f"Wavelength ({w_unit.to_string('latex_inline')})"
 
     elif self.wscale == "log":
         extent = [
-            (min(self.time) / t_unit).decompose(),
-            (max(self.time) / t_unit).decompose(),
-            np.log10(max(self.wavelength) / w_unit),
-            np.log10(min(self.wavelength) / w_unit),
+            self.time[0].to_value(t_unit),
+            self.time[-1].to_value(t_unit),
+            np.log10(self.wavelength[0].to_value(w_unit)),
+            np.log10(self.wavelength[-1].to_value(w_unit)),
         ]
         ylabel = r"log$_{10}$" + f"[Wavelength/({w_unit.to_string('latex_inline')})]"
 
@@ -72,8 +72,8 @@ def imshow(
         """
         warnings.warn(message)
         extent = [
-            (min(self.time) / t_unit).decompose(),
-            (max(self.time) / t_unit).decompose(),
+            self.time[0].to_value(t_unit),
+            self.time[-1].to_value(t_unit),
             self.nwave,
             0,
         ]

--- a/chromatic/rainbows/visualizations/plot.py
+++ b/chromatic/rainbows/visualizations/plot.py
@@ -100,5 +100,5 @@ def plot(
                 )
 
         # add text labels to the plot
-        plt.xlabel(f"Time ({t_unit.to_string('latex_inline')})")
+        plt.xlabel(f"{self._time_label} ({t_unit.to_string('latex_inline')})")
         plt.ylabel("Relative Flux (+ offsets)")

--- a/chromatic/tests/__init__.py
+++ b/chromatic/tests/__init__.py
@@ -5,7 +5,7 @@ from .test_rainbow_normalize import *
 from .test_rainbow_binning import *
 from .test_rainbow_simulations import *
 from .test_rainbow_visualizations import *
-from .test_rainbow_multi import *
+from .test_multi import *
 from .test_resampling import *
 from .test_units import *
 from .test_align_wavelengths import *

--- a/chromatic/tests/__init__.py
+++ b/chromatic/tests/__init__.py
@@ -5,6 +5,7 @@ from .test_rainbow_normalize import *
 from .test_rainbow_binning import *
 from .test_rainbow_simulations import *
 from .test_rainbow_visualizations import *
+from .test_rainbow_multi import *
 from .test_resampling import *
 from .test_units import *
 from .test_align_wavelengths import *

--- a/chromatic/tests/test_fold.py
+++ b/chromatic/tests/test_fold.py
@@ -1,0 +1,15 @@
+from ..rainbows import *
+from .setup_tests import *
+
+
+def test_fold():
+    original_time = np.linspace(-0.1, 0.1) * u.day
+
+    for i in range(5):
+        period = np.random.uniform(1, 20) * u.day
+        t0 = np.random.uniform(-10, 10) * u.day
+        N = np.random.randint(-10, 10)
+        s = SimulatedRainbow(time=original_time + t0 + period * N)
+        assert np.all(
+            np.isclose(s.fold(period=period, t0=t0).time, original_time, atol=1e-12)
+        )

--- a/chromatic/tests/test_multi.py
+++ b/chromatic/tests/test_multi.py
@@ -25,3 +25,16 @@ def test_multi():
     m.normalize()
     m.align_wavelengths().wavelength
     m[:, :]
+
+
+def test_compare_wrappers():
+    rainbows = [SimulatedRainbow(R=10 ** np.random.uniform(0.1, 2)) for _ in range(3)]
+
+    a = compare_rainbows(rainbows)
+    b = rainbows[0].compare(rainbows)
+
+    assert a.names == b.names
+    assert a.rainbows == b.rainbows
+
+    a.imshow()
+    b.imshow()

--- a/chromatic/tests/test_rainbow_basics.py
+++ b/chromatic/tests/test_rainbow_basics.py
@@ -103,5 +103,29 @@ def test_shape_warnings():
         d.ok = np.ones((d.nwave + 1, d.ntime + 1))
 
 
+def test_sort():
+    w = np.linspace(2, 1) * u.micron
+    t = np.linspace(1, -1) * u.day
+    r = SimulatedRainbow(wavelength=w, time=t)
+    print(r.wavelength)
+    print(r.time)
+    r._validate_core_dictionaries()
+    print(r.wavelength)
+    print(r.time)
+    assert np.all(r.wavelength == w[::-1])
+    assert np.all(r.time == t[::-1])
+
+    # test the warnings
+    with pytest.warns(match="input times were not monotonically increasing"):
+        r = SimulatedRainbow(time=t)
+        r._validate_core_dictionaries()
+        r.original_time_index
+
+    with pytest.warns(match="input wavelengths were not monotonically increasing"):
+        r = SimulatedRainbow(wavelength=w)
+        r._validate_core_dictionaries()
+        r.original_wave_index
+
+
 def test_help():
     Rainbow().help()

--- a/chromatic/version.py
+++ b/chromatic/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 
 def version():

--- a/docs/multi.ipynb
+++ b/docs/multi.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Comparing 🌈 to 🌈\n",
     "\n",
-    "Often, we'll want to directly compare two different Rainbows. A wrapper called `MultiRainbow` tries to make doing so a little simpler, by providing an interface to apply many of the familiar Rainbow methods to multiple objects at once."
+    "Often, we'll want to directly compare two different Rainbows. A wrapper called `compare_rainbows` tries to make doing so a little simpler, by providing an interface to apply many of the familiar `Rainbow` methods to multiple objects at once."
    ]
   },
   {
@@ -39,7 +39,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m = MultiRainbow([a, b, c], names=[\"noisy\", \"noisier\", \"noisiest\"])"
+    "c = compare_rainbows([a, b, c], names=[\"noisy\", \"noisier\", \"noisiest\"])"
    ]
   },
   {
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m.bin(R=4).plot(spacing=0.01)"
+    "c.bin(R=4).plot(spacing=0.01)"
    ]
   },
   {
@@ -59,7 +59,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m.imshow(cmap=\"gray\")"
+    "c.imshow(cmap=\"gray\")"
    ]
   },
   {
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m.animate_lightcurves()"
+    "c.animate_lightcurves()"
    ]
   },
   {
@@ -87,7 +87,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m.animate_spectra()"
+    "c.animate_spectra()"
    ]
   },
   {
@@ -101,7 +101,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -115,7 +115,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The changes here include:
- Add automatic sorting to wavelengths and times in *all* `Rainbow` objects. This is necessary to be able to compare between different ones. A warning is provided if the sorting changes anything, and the original indices are maintained.
- Add a `compare_rainbows` or `.compare` wrapper to provide multiple ways to generate a `MultiRainbow` object.
- Add `.name` (stored in `.metadata`) to all Rainbows, to provide another way to pass names into automatic comparisons with `MultiRainbow`.
- Fix some axis limits and formatting problems with `.imshow` for `MultiRainbow`.
- Make some structural changes to give access to its internal rainbows as either a list or a dictionary. Also, make sure that the internal rainbows are copies of the originals, so any changes that happen in place don't affect the original inputs.
- Add `.fold` action as an easy way to get to "Time from Mid-Transit" or "Time from Mid-Eclipse" for a particular planet.
- A few other tiny tidying things here and there.