### PR TITLE
add better keyword description to `.imshow`, `.plot`, `.animate...`

### DIFF
--- a/chromatic/rainbows/visualizations/animate.py
+++ b/chromatic/rainbows/visualizations/animate.py
@@ -86,8 +86,19 @@ def _setup_animate_lightcurves(
         The maximum value to use for the wavelength colormap
     scatterkw : dict
         A dictionary of keywords to be passed to `plt.scatter`
+        so you can have more detailed control over the plot
+        appearance. Common keyword arguments might include:
+        `[s, c, marker, alpha, linewidths, edgecolors, zorder]` (and more)
+        More details are available at
+        https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.scatter.html
     textkw : dict
-        A dictionary of keywords to be passed to `plt.text`
+        A dictionary of keywords passed to `plt.text`
+        so you can have more detailed control over the text
+        appearance. Common keyword arguments might include:
+        `[alpha, backgroundcolor, color, fontfamily, fontsize,
+          fontstyle, fontweight, rotation, zorder]` (and more)
+        More details are available at
+        https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.text.html
     """
 
     self._make_sure_cmap_is_defined(cmap=cmap, vmin=vmin, vmax=vmax)
@@ -183,8 +194,19 @@ def animate_lightcurves(
         The maximum value to use for the wavelength colormap
     scatterkw : dict
         A dictionary of keywords to be passed to `plt.scatter`
+        so you can have more detailed control over the plot
+        appearance. Common keyword arguments might include:
+        `[s, c, marker, alpha, linewidths, edgecolors, zorder]` (and more)
+        More details are available at
+        https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.scatter.html
     textkw : dict
-        A dictionary of keywords to be passed to `plt.text`
+        A dictionary of keywords passed to `plt.text`
+        so you can have more detailed control over the text
+        appearance. Common keyword arguments might include:
+        `[alpha, backgroundcolor, color, fontfamily, fontsize,
+          fontstyle, fontweight, rotation, zorder]` (and more)
+        More details are available at
+        https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.text.html
     """
     self._setup_animate_lightcurves(**kwargs)
 
@@ -237,12 +259,19 @@ def _setup_animate_spectra(
         The maximum value to use for the wavelength colormap
     scatterkw : dict
         A dictionary of keywords to be passed to `plt.scatter`
+        so you can have more detailed control over the plot
+        appearance. Common keyword arguments might include:
+        `[s, c, marker, alpha, linewidths, edgecolors, zorder]` (and more)
+        More details are available at
+        https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.scatter.html
     textkw : dict
-        A dictionary of keywords to be passed to `plt.text`
-    fps : int
-        Frames per second for the animation.
-    dpi : float, default: :rc:`savefig.dpi`
-        Dots per inch for the movie.
+        A dictionary of keywords passed to `plt.text`
+        so you can have more detailed control over the text
+        appearance. Common keyword arguments might include:
+        `[alpha, backgroundcolor, color, fontfamily, fontsize,
+          fontstyle, fontweight, rotation, zorder]` (and more)
+        More details are available at
+        https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.text.html
     """
 
     self._make_sure_cmap_is_defined(cmap=cmap, vmin=vmin, vmax=vmax)
@@ -346,12 +375,19 @@ def animate_spectra(
         The maximum value to use for the wavelength colormap
     scatterkw : dict
         A dictionary of keywords to be passed to `plt.scatter`
+        so you can have more detailed control over the plot
+        appearance. Common keyword arguments might include:
+        `[s, c, marker, alpha, linewidths, edgecolors, zorder]` (and more)
+        More details are available at
+        https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.scatter.html
     textkw : dict
-        A dictionary of keywords to be passed to `plt.text`
-    fps : int
-        Frames per second for the animation.
-    dpi : float, default: :rc:`savefig.dpi`
-        Dots per inch for the movie.
+        A dictionary of keywords passed to `plt.text`
+        so you can have more detailed control over the text
+        appearance. Common keyword arguments might include:
+        `[alpha, backgroundcolor, color, fontfamily, fontsize,
+          fontstyle, fontweight, rotation, zorder]` (and more)
+        More details are available at
+        https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.text.html
     """
     self._setup_animate_spectra(**kwargs)
 

--- a/chromatic/rainbows/visualizations/imshow.py
+++ b/chromatic/rainbows/visualizations/imshow.py
@@ -31,6 +31,13 @@ def imshow(
         Should we include a colorbar?
     aspect : str
         What aspect ratio should be used for the imshow?
+    kw : dict
+        All other keywords will be passed on to `plt.imshow`,
+        so you can have more detailed control over the plot
+        appearance. Common keyword arguments might include:
+        `[cmap, norm, interpolation, alpha, vmin, vmax]` (and more)
+        More details are available at
+        https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html
     """
 
     # self.speak(f'imshowing')

--- a/chromatic/rainbows/visualizations/plot.py
+++ b/chromatic/rainbows/visualizations/plot.py
@@ -38,8 +38,20 @@ def plot(
         The maximum value to use for the wavelength colormap.
     plotkw : dict
         A dictionary of keywords passed to `plt.plot`
+        so you can have more detailed control over the plot
+        appearance. Common keyword arguments might include:
+        `[alpha, clip_on, zorder, marker, markersize,
+          linewidth, linestyle, zorder]` (and more)
+        More details are available at
+        https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.plot.html
     textkw : dict
         A dictionary of keywords passed to `plt.text`
+        so you can have more detailed control over the text
+        appearance. Common keyword arguments might include:
+        `[alpha, backgroundcolor, color, fontfamily, fontsize,
+          fontstyle, fontweight, rotation, zorder]` (and more)
+        More details are available at
+        https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.text.html
     """
 
     # make sure that the wavelength-based colormap is defined


### PR DESCRIPTION
The changes are:
- Some tiny additions to the docstrings for some visualizations, to make it clearer that you can supply normal `matplotlib` keywords to many of them.