### PR TITLE
add simple wrappers to get light curve and spectrum as arrays

### DIFF
--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -871,6 +871,9 @@ class Rainbow:
         get_typical_uncertainty,
     )
 
+    # import summary statistics for each wavelength
+    from .timelike_summaries import get_lightcurve
+
     # import visualizations that can act on Rainbows
     from .visualizations import (
         imshow,

--- a/chromatic/rainbows/timelike_summaries/__init__.py
+++ b/chromatic/rainbows/timelike_summaries/__init__.py
@@ -1,0 +1,1 @@
+from .lightcurve import *

--- a/chromatic/rainbows/timelike_summaries/lightcurve.py
+++ b/chromatic/rainbows/timelike_summaries/lightcurve.py
@@ -1,0 +1,17 @@
+from ...imports import *
+
+__all__ = ["get_lightcurve"]
+
+
+def get_lightcurve(self):
+    """
+    Return a lightcurve of the star, averaged over all wavelengths.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+    lightcurve : np.array (wavelike)
+    """
+    return self.get_lightcurve_as_rainbow().flux[0, :]

--- a/chromatic/rainbows/wavelike_summaries/spectrum.py
+++ b/chromatic/rainbows/wavelike_summaries/spectrum.py
@@ -10,11 +10,8 @@ def get_spectrum(self):
     Parameters
     ----------
 
-
     Returns
     -------
-    s : np.array (wavelike)
+    spectrum : np.array (wavelike)
     """
-
-    # FIXME, think about error weighting/masking
-    return np.nanmedian(self.flux, axis=self.timeaxis)
+    return self.get_spectrum_as_rainbow().flux[:, 0]

--- a/chromatic/tests/test_summaries.py
+++ b/chromatic/tests/test_summaries.py
@@ -1,0 +1,9 @@
+from ..rainbows import *
+from .setup_tests import *
+
+
+def test_lightcurve_and_spectrum_summaries():
+    fi, ax = plt.subplots(1, 2, sharey=True)
+    s = SimulatedRainbow().inject_transit()
+    ax[0].plot(s.time, s.get_lightcurve())
+    ax[1].plot(s.wavelength, s.get_spectrum())


### PR DESCRIPTION
Closes #45 . If you just want the light curve or spectrum flux values, use `.get_lightcurve` or `.get_spectrum`. If you want uncertainties and other useful things too, use `.get_lightcurve_as_rainbow` and `.get_spectrum_as_rainbow`.