### PR TITLE
Add `.inject_systematics` and tools for comparing data to models.

### DIFF
--- a/chromatic/rainbows/__init__.py
+++ b/chromatic/rainbows/__init__.py
@@ -1,3 +1,4 @@
+from .withmodel import *
 from .rainbow import *
 from .simulated import *
 from .multi import *

--- a/chromatic/rainbows/actions/__init__.py
+++ b/chromatic/rainbows/actions/__init__.py
@@ -4,5 +4,6 @@ from .normalization import *
 from .align_wavelengths import *
 from .conversions import *
 from .inject_transit import *
+from .inject_systematics import *
 from .fold import *
 from .compare import *

--- a/chromatic/rainbows/actions/inject_systematics.py
+++ b/chromatic/rainbows/actions/inject_systematics.py
@@ -1,0 +1,236 @@
+from ...imports import *
+import batman
+
+__all__ = [
+    "inject_systematics",
+    "_create_fake_wavelike_quantity",
+    "_create_fake_timelike_quantity",
+    "_create_fake_fluxlike_quantity",
+]
+
+"""
+The idea for simple GP-generated systematics came from the fabulous
+tutorial Neale Gibson led for the ers-transit team in summer 2021
+
+The recording and a follow-along notebook are available at
+https://ers-transit.github.io/pre-launch-hackathon.html
+"""
+
+
+def create_covariance_matrix(x, correlated=1, length=3, uncorrelated=0.5):
+    """
+    Generate a covariance matrix from a squared-exponential kernel
+    with an additional diagonal component. The kernel is given by
+    the following expression for x[m] and x[n]:
+
+    distance = x[m] - x[n]
+    correlated**2 * exp(-0.5*distance**2/length**2) + uncorrelated**2 * delta(m,n)
+
+    It will be normalized to correlated**2 + uncorrelated**2 = 1
+
+    Parameters
+    ----------
+    x : np.array or u.Quantity
+        The arry of values for generating the matrix.
+    correlated : float
+        The amplitude of the correlated noise component.
+    length : float or u.Quantity
+        The length scale of the correlation (in same units as x)
+    uncorrelated : float
+        The amplitude of the uncorrelated noise component.
+    """
+
+    # what's the distance between each point and each other (an square matrix)
+    distance_squared = np.subtract.outer(x, x) ** 2
+
+    # calculate normalized coefficients
+    N = correlated**2 + uncorrelated**2
+    A, B = correlated / N, uncorrelated / N
+
+    # generate the covariance matrix with squared exponential kernel
+    covariance_matrix = A**2 * np.exp(-0.5 * distance_squared / length**2)
+
+    # add extra variance along the diagonal
+    i = np.arange(len(x))
+    covariance_matrix[i, i] += B**2
+
+    return covariance_matrix
+
+
+def _create_fake_timelike_quantity(
+    self, mean=np.zeros_like, correlated=1, dt=0.5 * u.hour, uncorrelated=0.25
+):
+    """
+    Create a fake timelike quantity.
+
+    Parameters
+    ----------
+    mean : function
+        A function that takes in an array of times and returns
+        a mean value for each time. The fake timeseries will
+        wobble around that mean, according to the covariance
+        matrix.
+    correlated : float
+        The amplitude of the correlated noise component.
+    dt : u.Quantity
+        The time scale of the correlation (in units of time).
+    uncorrelated : float
+        The amplitude of the uncorrelated noise component.
+        (correlated and uncorrelated will be normalized to 1)
+    Returns
+    -------
+    timelike : np.array
+        A timelike array with the requested noise properties.
+    """
+    x = self.time
+    covariance_matrix = create_covariance_matrix(
+        x, correlated=correlated, length=dt, uncorrelated=uncorrelated
+    )
+    return np.random.multivariate_normal(mean(x), covariance_matrix)
+
+
+def _create_fake_wavelike_quantity(
+    self, mean=np.zeros_like, correlated=1, R=5, uncorrelated=0.25
+):
+    """
+    Create a fake timelike quantity.
+
+    Parameters
+    ----------
+    mean : function
+        A function that takes in an array of times and returns
+        a mean value for each time. The fake timeseries will
+        wobble around that mean, according to the covariance
+        matrix.
+    correlated : float
+        The amplitude of the correlated noise component.
+    dt : u.Quantity
+        The time scale of the correlation (in units of time).
+    uncorrelated : float
+        The amplitude of the uncorrelated noise component.
+        (correlated and uncorrelated will be normalized to 1)
+
+    Returns
+    -------
+    wavelike : np.array
+        A wavelike array with the requested noise properties.
+    """
+    x = np.log(self.wavelength.value)
+    covariance_matrix = create_covariance_matrix(
+        x, correlated=correlated, length=1 / R, uncorrelated=uncorrelated
+    )
+    return np.random.multivariate_normal(mean(x), covariance_matrix)
+
+
+def _create_fake_fluxlike_quantity(self, timelike_kw={}, wavelike_kw={}):
+    """
+    Create a fake fluxlike quantity.
+
+    Parameters
+    ----------
+    timelike_kw : dict
+        Dictionary of keywords to pass to `_create_fake_timelike_quantity()`
+
+    Returns
+    -------
+    fluxlike : np.array
+        A fluxlike array (with )
+    """
+
+    # create a 1D time array
+    tkw = dict(correlated=1, uncorrelated=0.5, dt=1 * u.hour)
+    tkw.update(**timelike_kw)
+    t = self._create_fake_timelike_quantity(**tkw)
+
+    # create a 1D wavelength array
+    wkw = dict(correlated=1, uncorrelated=0, R=5)
+    wkw.update(**wavelike_kw)
+    w = self._create_fake_wavelike_quantity(**wkw)
+
+    # multiply them together and return
+    f = w[:, np.newaxis] * t[np.newaxis, :]
+    return f
+
+
+def inject_systematics(
+    self,
+    amplitude=0.005,
+    wavelike=[],
+    timelike=["x", "y", "time"],
+    fluxlike=["background"],
+):
+
+    """
+    Inject some (very cartoony) instrumental systematics.
+
+    Here's the basic procedure:
+
+    1) Generate some fake variables that vary either just with
+    wavelength, just with time, or with both time and wavelength.
+    Store these variables for later use. For example, these might
+    represent an average `x` and `y` centroid of the trace on the
+    detector (one for each time), or the background flux associated
+    with each wavelength (one for each time and for each wavelength).
+
+    2) Generate a flux model as some function of those variables.
+    In reality, we probably don't know the actual relationship
+    between these inputs and the flux, but we can imagine one!
+
+    3) Inject the model flux into the `flux` of this Rainbow,
+    and store the combined model in `systematics-model` and
+    each individual component in `systematic-model-{...}`.
+    """
+
+    # create a history entry for this action (before other variables are defined)
+    h = self._create_history_entry("inject_systematics", locals())
+
+    # create a copy of the existing Rainbow
+    new = self._create_copy()
+    new.fluxlike["systematics_model"] = np.ones(self.shape)
+
+    def standardize(q):
+
+        return u.Quantity((q - np.nanmean(q)) / np.nanstd(q)).value
+
+    for k in wavelike:
+        if k in self.wavelike:
+            x = standardize(self.wavelike[k])
+        else:
+            x = new._create_fake_wavelike_quantity()
+            new.wavelike[k] = x
+        c = np.random.normal(0, amplitude)
+        df = c * x[:, np.newaxis] * np.ones(self.shape)
+        new.fluxlike[f"systematics_model_from_{k}"] = df
+        new.fluxlike["systematics_model"] += df
+
+    for k in timelike:
+        if k in self.timelike:
+            x = standardize(self.timelike[k])
+        else:
+            x = new._create_fake_timelike_quantity()
+            new.timelike[k] = x
+        c = np.random.normal(0, amplitude)
+        df = c * x[np.newaxis, :] * np.ones(self.shape)
+        new.fluxlike[f"systematics_model_from_{k}"] = df
+        new.fluxlike["systematics_model"] += df
+
+    for k in fluxlike:
+        if k in self.fluxlike:
+            x = standardize(self.fluxlike[k])
+        else:
+            x = new._create_fake_fluxlike_quantity()
+            new.fluxlike[k] = x
+        c = np.random.normal(0, amplitude)
+        df = c * x * np.ones(self.shape)
+        new.fluxlike[f"systematics_model_from_{k}"] = df
+        new.fluxlike["systematics_model"] += df
+
+    # modify both the model and flux arrays
+    new.flux *= new.systematics_model
+    new.model = new.fluxlike.get("model", 1) * new.systematics_model
+
+    # append the history entry to the new Rainbow
+    new._record_history_entry(h)
+
+    # return the new object
+    return new

--- a/chromatic/rainbows/actions/inject_systematics.py
+++ b/chromatic/rainbows/actions/inject_systematics.py
@@ -154,7 +154,7 @@ def _create_fake_fluxlike_quantity(self, timelike_kw={}, wavelike_kw={}):
 
 def inject_systematics(
     self,
-    amplitude=0.005,
+    amplitude=0.003,
     wavelike=[],
     timelike=["x", "y", "time"],
     fluxlike=["background"],

--- a/chromatic/rainbows/actions/inject_transit.py
+++ b/chromatic/rainbows/actions/inject_transit.py
@@ -53,7 +53,7 @@ def inject_transit(self, planet_params={}, planet_radius=0.1):
     h = self._create_history_entry("inject_transit", locals())
 
     # create a copy of the existing Rainbow
-    result = self._create_copy()
+    new = self._create_copy()
 
     # First, make sure planet_radius has the right dimension.
     if type(planet_radius) != float and len(planet_radius) != self.nwave:
@@ -122,18 +122,15 @@ def inject_transit(self, planet_params={}, planet_radius=0.1):
         try:
             m
         except NameError:
-            m = batman.TransitModel(params, result.time.to_value("day"))
+            m = batman.TransitModel(params, new.time.to_value("day"))
         planet_flux[i] = m.light_curve(params)
 
-    # replace its flux (and model)
-    try:
-        result.fluxlike["model"] *= planet_flux
-    except KeyError:
-        pass
-    result.fluxlike["flux"] *= planet_flux
+    new.planet_model = planet_flux
+    new.flux *= new.planet_model
+    new.model = new.fluxlike.get("model", 1) * new.planet_model
 
     # append the history entry to the new Rainbow
-    result._record_history_entry(h)
+    new._record_history_entry(h)
 
     # return the new object
-    return result
+    return new

--- a/chromatic/rainbows/actions/operations.py
+++ b/chromatic/rainbows/actions/operations.py
@@ -253,6 +253,7 @@ def __eq__(self, other):
 
         # pull out each core dictionary from both
         d1, d2 = vars(self)[d], vars(other)[d]
+        same *= d1.keys() == d2.keys()
 
         # loop through elements of each dictionary
         for k in d1:

--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -860,6 +860,10 @@ class Rainbow:
         compare,
         get_lightcurve_as_rainbow,
         get_spectrum_as_rainbow,
+        inject_systematics,
+        _create_fake_wavelike_quantity,
+        _create_fake_timelike_quantity,
+        _create_fake_fluxlike_quantity,
         to_nparray,
         to_df,
     )

--- a/chromatic/rainbows/readers/rainbow_FITS.py
+++ b/chromatic/rainbows/readers/rainbow_FITS.py
@@ -27,7 +27,18 @@ def from_rainbow_FITS(rainbow, filepath):
     hdu_list = fits.open(filepath)
 
     # load the header into metadata
-    rainbow.metadata = dict(hdu_list["primary"].header)
+    h = hdu_list["primary"].header
+    for k in h:
+        if k.lower() in [
+            "name",
+            "wscale",
+            "tscale",
+            "signal_to_noise",
+            "history",
+        ]:  # KLUDGE!
+            rainbow.metadata[k.lower()] = h[k]
+        elif k not in ["SIMPLE", "BITPIX", "NAXIS", "EXTEND"]:
+            rainbow.metadata[k] = h[k]
 
     # load into the three core dictionaries
     for e in ["fluxlike", "wavelike", "timelike"]:

--- a/chromatic/rainbows/simulated.py
+++ b/chromatic/rainbows/simulated.py
@@ -93,7 +93,7 @@ class SimulatedRainbow(Rainbow):
         # If the flux of the star is not given,
         # assume a continuum-normlized flux where fx=1 at all wavelengths.
         if star_flux is None:
-            self.fluxlike["model"] = np.ones(self.shape)
+            model = np.ones(self.shape)
 
         # If the flux vs wavelength of the star is supplied,
         # include it in the model.
@@ -101,13 +101,13 @@ class SimulatedRainbow(Rainbow):
             # Check to make sure the flux and wavelengths
             # have the same shape.
             if len(star_flux) == len(self.wavelike["wavelength"]):
-                self.fluxlike["model"] = np.transpose([star_flux] * self.shape[1])
+                model = np.transpose([star_flux] * self.shape[1])
 
         # Set uncertainty.
-        self.fluxlike["uncertainty"] = self.fluxlike["model"] / signal_to_noise
-        self.fluxlike["flux"] = np.random.normal(
-            self.fluxlike["model"], self.fluxlike["uncertainty"]
-        )
+        uncertainty = model / signal_to_noise
+        self.fluxlike["flux"] = np.random.normal(model, uncertainty)
+        self.fluxlike["uncertainty"] = uncertainty
+        self.fluxlike["model"] = model
 
         # make sure everything is defined and sorted
         self._validate_core_dictionaries()

--- a/chromatic/rainbows/simulated.py
+++ b/chromatic/rainbows/simulated.py
@@ -1,7 +1,18 @@
-from .rainbow import *
+from .withmodel import *
 
 
-class SimulatedRainbow(Rainbow):
+class SimulatedRainbow(RainbowWithModel):
+    """
+    `SimulatedRainbow` objects are created from scratch
+    within `chromatic`, with options for various different
+    wavelength grids, time grids, noise sources, and injected
+    models. They can be useful for generating quick simulated
+    dataset for testing analysis and visualization tools.
+
+    This class definition inherits from `RainbowWithModel`,
+    which itself inherits from `Rainbow`.
+    """
+
     def __init__(
         self,
         signal_to_noise=100,

--- a/chromatic/rainbows/visualizations/imshow.py
+++ b/chromatic/rainbows/visualizations/imshow.py
@@ -124,8 +124,9 @@ def imshow(
     imshow_kw.update(**kw)
     with quantity_support():
         plt.sca(ax)
+        z = self.get(quantity)
         plt.imshow(
-            self.fluxlike[quantity],
+            z,
             extent=self._imshow_extent,
             aspect=aspect,
             origin="upper",
@@ -136,8 +137,6 @@ def imshow(
         if colorbar:
             plt.colorbar(
                 ax=ax,
-                label=u.Quantity(self.fluxlike[quantity]).unit.to_string(
-                    "latex_inline"
-                ),
+                label=u.Quantity(z).unit.to_string("latex_inline"),
             )
     return ax

--- a/chromatic/rainbows/withmodel.py
+++ b/chromatic/rainbows/withmodel.py
@@ -1,0 +1,152 @@
+from .rainbow import *
+
+
+class RainbowWithModel(Rainbow):
+    """
+    `RainbowWithModel` objects have a fluxlike `model`
+    attached to them, meaning that they can
+
+    This class definition inherits from `Rainbow`.
+    """
+
+    @property
+    def residuals(self):
+        """
+        Calculate the residuals on the fly,
+        to make sure they're always up to date.
+        """
+        return self.flux - self.model
+
+    def _validate_core_dictionaries(self):
+        super()._validate_core_dictionaries()
+        try:
+            model = self.get("model")
+            assert np.shape(model) == np.shape(self.flux)
+        except (AttributeError, AssertionError):
+            message = """
+            No fluxlike 'model' was found attached to this
+            `RainbowWithModel` object. The poor thing,
+            its name is a lie! Please connect a model.
+            The simplest way to do so might look like...
+            `rainbow.model = np.ones(rainbow.shape)`
+            ...or similarly with a more interesting array.
+            """
+            warnings.warn(message)
+
+    def imshow_data_with_models(
+        self,
+        models=["model"],
+        vlimits_data=[0.98, 1.02],
+        vspan_residuals=0.02,
+        figsize=(8, 3),
+        **kw,
+    ):
+        """
+        Produce a multi-panel imshow figure comparing
+        the data to model components. The left panel
+        will be the data ('flux'), the right panel will
+        be the residuals ('flux' - 'model'), and the middle
+        panel(s) will be the model(s) connecting them.
+
+        Parameters
+        ----------
+        models : list
+            The list of model quantities to display,
+            each in its own panel. A popular option might be:
+            `models = ['systematics_model', 'planet_model']
+            Whatever you include here does not affect the
+            values of the Residuals panel, which are always
+            exactly 'flux' - 'model'.
+        vlimits_data : list
+            The value limits for the data and model colormap,
+            specified as `vlimits_data = [vmin, vmax]`.
+            If `None` or `[None, None]`, the limits will be
+            replaced with the [1,99] percentiles of the flux.
+        vspan_residuals : float
+            The distance away from zero where the colormap
+            for the residuals will cut off. If `None`, the
+            span will be set to 3 standard deviations.
+        figsize : tuple
+            The figure size for the multipanel plot.
+            It should probably be wider than it is tall.
+        """
+        # make sure color limits are set for data and model
+        percentiles = [1, 99]
+        if vlimits_data is None:
+            vlimits_data = np.percentile(self.flux, percentiles)
+        elif vlimits_data[0] is None:
+            vlimits_data[0] = np.percentile(self.flux, percentiles[0])
+        elif vlimits_data[1] is None:
+            vlimits_data[1] = np.percentile(self.flux, percentiles[1])
+
+        # make sure color limits are set for the residuals
+        if vspan_residuals is None:
+            vspan_residuals = np.nanstd(self.residuals) * 3
+
+        # set up the panels
+        row_data, row_colorbar = 1, 0
+        N = len(models) + 2
+        fi, ax = plt.subplots(
+            2,
+            N,
+            figsize=figsize,
+            dpi=600,
+            gridspec_kw=dict(height_ratios=[1, 20]),
+            sharex="row",
+            sharey="row",
+            constrained_layout=True,
+        )
+
+        # a helper function to make better titles
+        def create_title(s):
+            if s == "flux":
+                return "Data"
+            else:
+                return s.replace("_", " ").title()
+
+        # plot the first three panels
+        for i, k in enumerate(["flux"] + models):
+            self.imshow(
+                ax=ax[row_data, i],
+                quantity=k,
+                vmin=vlimits_data[0],
+                vmax=vlimits_data[1],
+                colorbar=False,
+                **kw,
+            )
+            ax[row_data, i].set_title(create_title(k))
+
+        # set up the colorbar to span the data and models
+        gs = ax[row_colorbar, 0].get_gridspec()
+        for a in ax[row_colorbar, :-1]:
+            a.remove()
+        ax_colorbar = fi.add_subplot(gs[row_colorbar, :-1])
+        plt.colorbar(cax=ax_colorbar, orientation="horizontal")
+
+        # plot the residuals
+        k = "residuals"
+        self.imshow(
+            ax[row_data, -1],
+            k,
+            vmin=-vspan_residuals,
+            vmax=vspan_residuals,
+            colorbar=False,
+            **kw,
+        )
+        ax[row_data, -1].set_title("Residuals")
+
+        # set up the colorbar for the residuals
+        ax_colorbar_residuals = plt.subplot(gs[row_colorbar, -1])
+        cbar = plt.colorbar(cax=ax_colorbar_residuals, orientation="horizontal")
+        for a in [ax_colorbar, ax_colorbar_residuals]:
+            a.tick_params(labelsize=8)
+        x = vspan_residuals / 2
+        cbar.set_ticks([-x, 0, x], labels=[f"{-x:.2}", "0", f"{x:.2}"])
+
+        # clear all the axis labels and replace with shared
+        for a in ax[row_data, :]:
+            xlabel, ylabel = a.get_xlabel(), a.get_ylabel()
+            a.set_ylabel("")
+            a.set_xlabel("")
+        fi.supxlabel(xlabel)
+        fi.supylabel(ylabel)

--- a/chromatic/tests/__init__.py
+++ b/chromatic/tests/__init__.py
@@ -10,3 +10,4 @@ from .test_resampling import *
 from .test_units import *
 from .test_align_wavelengths import *
 from .test_conversions import *
+from .test_withmodel import *

--- a/chromatic/tests/test_align_wavelengths.py
+++ b/chromatic/tests/test_align_wavelengths.py
@@ -55,9 +55,9 @@ def test_align_wavelengths(fractional_shift=0.002, dw=0.0001 * u.micron):
 
     fi, ax = plt.subplots(2, 2, dpi=300, figsize=(8, 6))
     for i, x in enumerate([r, a]):
-        x.imshow(ax=ax[0, i], quantity="flux")
+        ax[0, i].imshow(x.flux)
         plt.title(["original", "aligned"][i] + " flux")
-        x.imshow(ax=ax[1, i], quantity="wavelength")
+        ax[1, i].imshow(x.fluxlike["wavelength"])
         plt.title(["original", "aligned"][i] + " wavelength")
     plt.tight_layout()
 

--- a/chromatic/tests/test_inject_systematics.py
+++ b/chromatic/tests/test_inject_systematics.py
@@ -1,0 +1,9 @@
+from ..rainbows import *
+from .setup_tests import *
+
+
+def test_inject_systematics():
+    SimulatedRainbow().inject_transit().inject_systematics().bin(
+        R=10, dt=10 * u.minute
+    ).imshow_quantities()
+    plt.savefig(os.path.join(test_directory, "inject_systematics_demo.pdf"))

--- a/chromatic/tests/test_withmodel.py
+++ b/chromatic/tests/test_withmodel.py
@@ -1,0 +1,31 @@
+from ..rainbows import *
+from .setup_tests import *
+
+
+def test_attach_model():
+    simulated = SimulatedRainbow().inject_transit().inject_systematics()
+    original = simulated._create_copy()
+
+    # pull out the model
+    inputs = {}
+    for k in ["model", "planet_model", "systematics_model"]:
+        inputs[k] = simulated.fluxlike[k]
+        del simulated.fluxlike[k]
+
+    # reattach the model
+    withmodel = simulated.attach_model(**inputs)
+    assert simulated != withmodel
+    assert withmodel == original
+
+
+def test_imshow_data_with_models():
+    s = (
+        SimulatedRainbow()
+        .inject_transit()
+        .inject_systematics()
+        .bin(R=50, dt=5 * u.minute)
+    )
+    s.imshow_data_with_models(cmap="gray")
+    plt.savefig(os.path.join(test_directory, "imshow-data-with-model.pdf"))
+    s.imshow_data_with_models(models=["systematics_model", "planet_model"], cmap="gray")
+    plt.savefig(os.path.join(test_directory, "imshow-data-with-model-components.pdf"))

--- a/chromatic/version.py
+++ b/chromatic/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 
 def version():


### PR DESCRIPTION
The major changes here include:
- Add `.inject_systematics` that can generate semi-realistic instrumental systematic noise and inject it into a `Rainbow`. It constructs a linear model of various input timelike, wavelike, and/or fluxlike quantities. The input quantities can be ones that already exist (like `time`) or ones that get randomly generated as draws from a Gaussian process (like `x`, which in real datasets tends to have some high-frequency jitter along with slower drifts and wobbles). The inputs are all stored in the injected `Rainbow` so they can (in principle) be used to fit out the systematics. 
- Add `RainbowWithModel` class definition. The main requirement for these objects is simply that they have a fluxlike `'model'`. All `SimulatedRainbow` objects will inherit from `RainbowWithModel`, and any `Rainbow` can generate a new `RainbowWithModel` object via the `.attach_model()` method. These objects will automatically calculate residuals based on the current data and model, and they have some visualization tools.
- Add `.imshow_data_with_models()` function to display the raw flux, any model components that help explain it, and the residuals from the combined model. Hopefully this will help as a quick tool for visualizing fits! 

Example usage looks like:
```python
from chromatic import *
(
  SimulatedRainbow()
  .inject_transit()
  .inject_systematics()
  .bin(R=50, dt=5 * u.minute)
  .imshow_data_with_models(
    models=["systematics_model", "planet_model"], 
    cmap="gray"
  )
)
```
![imshow-data-with-model-components](https://user-images.githubusercontent.com/4691081/172943955-e1134eb9-91e3-47b8-b10f-1ed81d3e9e91.png)