### PR TITLE
Add imshow flexibility

### DIFF
--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -555,7 +555,7 @@ class Rainbow:
         message = f"🌈.{key} does not exist for this Rainbow"
         raise AttributeError(message)
 
-    def get(self, key):
+    def get(self, key, default=None):
         """
         Retrieve an attribute by its string name.
         (This is a friendlier wrapper for `getattr()`).
@@ -567,8 +567,13 @@ class Rainbow:
         because it can also be used to get the results of
         properties that do calculations on the fly (for example,
         `r.residuals` in the `RainbowWithModel` class).
+
+        This will default to None if the attribute can't be found.
         """
-        return getattr(self, key)
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            return None
 
     def __setattr__(self, key, value):
         """

--- a/chromatic/rainbows/visualizations/__init__.py
+++ b/chromatic/rainbows/visualizations/__init__.py
@@ -6,3 +6,4 @@ from .diagnostics import *
 from .interactive import *
 from .plot_spectra import *
 from .plot import *
+from .utilities import *

--- a/chromatic/rainbows/visualizations/diagnostics/plot_quantities.py
+++ b/chromatic/rainbows/visualizations/diagnostics/plot_quantities.py
@@ -6,21 +6,21 @@ __all__ = ["plot_quantities"]
 def plot_quantities(
     self,
     quantities=None,
-    data_like="time",
+    xaxis="time",
     maxcol=1,
     panel_size=(6, 2),
     x_axis="index",
     **kw,
 ):
     """
-    Plot {data_like}-like quantities as a function of {data_like} index
-    or any other {data_like} quantity (such as "time" or "wavelength").
+    Plot {xaxis}-like quantities as a function of {xaxis} index
+    or any other {xaxis} quantity (such as "time" or "wavelength").
 
     Parameters
     ----------
     quantities : list like
         The X-like quantity to plot.
-    data_like : string
+    xaxis : string
         Whether the quantities are alike to 'time' or 'wave'. Default is 'time'. (Optional)
     maxcol : int
         The maximum number of columns to show (Optional).
@@ -31,9 +31,9 @@ def plot_quantities(
 
     """
     # decide which dictionary to plot
-    if data_like not in ["time", "wave", "wavelength"]:
-        raise Exception("Unknown data_like. Choose from [time, wave]")
-    elif data_like == "time":
+    if xaxis not in ["time", "wave", "wavelength"]:
+        raise Exception("Unknown xaxis. Choose from [time, wave]")
+    elif xaxis == "time":
         like_dict = self.timelike
     else:
         like_dict = self.wavelike
@@ -69,7 +69,7 @@ def plot_quantities(
     # set x_axis variable
     if x_axis.lower() == "index":
         xaxis = np.arange(0, len(like_dict[list(like_dict.keys())[0]]))
-        xlab = f"{data_like} Index"
+        xlab = f"{xaxis} Index"
     else:
         if x_axis in like_dict.keys():
             xaxis = like_dict[x_axis]

--- a/chromatic/rainbows/visualizations/plot_spectra.py
+++ b/chromatic/rainbows/visualizations/plot_spectra.py
@@ -119,7 +119,7 @@ def plot_spectra(
         #  loop through times
         for i, t in enumerate(self.time):
             # grab the spectrum for this particular time
-            quan = self.fluxlike[quantity][:, i]
+            quan = u.Quantity(self.fluxlike[quantity][:, i]).value
             fluxerr = self.fluxlike["uncertainty"][:, i]
             if np.any(np.isfinite(quan)):
 
@@ -136,7 +136,7 @@ def plot_spectra(
                 this_scatterkw = dict(
                     marker="o",
                     linestyle="-",
-                    c=self.wavelength.to(w_unit),
+                    c=self.wavelength.to_value(w_unit),
                     cmap=self.cmap,
                     norm=self.norm,
                 )
@@ -170,3 +170,5 @@ def plot_spectra(
         # add text labels to the plot
         plt.xlabel(f"Wavelength ({w_unit.to_string('latex_inline')})")
         plt.ylabel("Relative Flux (+ offsets)")
+        if self.get("wscale") == "log":
+            plt.xscale("log")

--- a/chromatic/rainbows/visualizations/utilities.py
+++ b/chromatic/rainbows/visualizations/utilities.py
@@ -1,0 +1,33 @@
+from ...imports import *
+
+__all__ = ["_add_panel_labels"]
+
+
+def _add_panel_labels(axes, preset="inside", **kw):
+    """
+    Add (a), (b), (c) labels to a group of axes.
+
+    Parameters
+    ----------
+    ax : list or array of matplotlib.axes._subplots.AxesSubplot objects
+        The axes into which the labels should be drawn.
+    preset : str
+        A few presets for where to put the labels relative to
+        upper left corner of each panel. Options are ['inside', 'above']
+    kw : dict
+        All addition keywords will be passed to `plt.text`,
+        and they will overwrite defaults.
+    """
+
+    textkw = dict(x=0.02, y=0.98, va="top", ha="left")
+    if preset == "inside":
+        textkw.update(x=0.02, y=0.98, va="top", color="white")
+    elif preset == "outside":
+        textkw.update(x=0, y=1.02, va="bottom", color="black")
+    textkw.update(**kw)
+
+    letters = "abcdefghijklmnopqrstuvwxyz"
+    for i, a in enumerate(axes.flatten()):
+        textkw["s"] = f"({letters[i]})"
+        textkw["transform"] = a.transAxes
+        a.text(**textkw)

--- a/chromatic/rainbows/withmodel.py
+++ b/chromatic/rainbows/withmodel.py
@@ -1,4 +1,5 @@
 from .rainbow import *
+from .visualizations import _add_panel_labels
 
 
 class RainbowWithModel(Rainbow):
@@ -39,6 +40,8 @@ class RainbowWithModel(Rainbow):
         vlimits_data=[0.98, 1.02],
         vspan_residuals=0.02,
         figsize=(8, 3),
+        label="inside",
+        labelkw={},
         **kw,
     ):
         """
@@ -69,6 +72,17 @@ class RainbowWithModel(Rainbow):
         figsize : tuple
             The figure size for the multipanel plot.
             It should probably be wider than it is tall.
+        label : bool
+            Should we add (a), (b), (c) labels to the panels,
+            and where? False or None give no labels, 'inside'
+            sets them in the upper left inside corner, 'outside'
+            sets them above the upper left corner.
+        labelkw : dict
+            Keywords to pass along to the `plt.text` command
+            that makes the labels.
+        kw : dict
+            All additional keywords will be passed along
+            to `Rainbow.imshow` for all imshow panels.
         """
         # make sure color limits are set for data and model
         percentiles = [1, 99]
@@ -150,3 +164,6 @@ class RainbowWithModel(Rainbow):
             a.set_xlabel("")
         fi.supxlabel(xlabel)
         fi.supylabel(ylabel)
+
+        if label:
+            _add_panel_labels(ax[row_data, :], preset=label, **labelkw)

--- a/chromatic/tests/test_visualizations.py
+++ b/chromatic/tests/test_visualizations.py
@@ -168,7 +168,7 @@ def test_both_types_of_plot():
             spacing=0,
             errorbar=True,
             plotkw=dict(color="orchid"),
-            scatterkw=dict(c="orchid"),
+            scatterkw=dict(),
             textkw=dict(color="orchid"),
             errorbarkw=dict(color="orchid"),
         )

--- a/chromatic/tests/test_visualizations.py
+++ b/chromatic/tests/test_visualizations.py
@@ -1,5 +1,6 @@
 from ..rainbows import *
 from .setup_tests import *
+from ..rainbows.visualizations import _add_panel_labels
 
 
 def test_imshow():
@@ -51,7 +52,7 @@ def test_plot_quantities():
 
     for k in ["time", "wavelength"]:
         for x in [k, "index"]:
-            r.plot_quantities(data_like=k, x_axis=x)
+            r.plot_quantities(xaxis=k, x_axis=x)
             plt.savefig(
                 os.path.join(
                     test_directory,

--- a/chromatic/tests/test_visualizations.py
+++ b/chromatic/tests/test_visualizations.py
@@ -175,3 +175,8 @@ def test_both_types_of_plot():
     plt.savefig(
         os.path.join(test_directory, "test-plot-lightcurve-and-spectra-many.png")
     )
+
+
+def test_add_labels_to_panels():
+    fi, ax = plt.subplots(3, 3)
+    _add_panel_labels(ax, preset="inside", color="blue")

--- a/chromatic/tests/test_visualizations.py
+++ b/chromatic/tests/test_visualizations.py
@@ -136,6 +136,20 @@ def test_imshow_randomized_axes():
             assert "Wavelength Index" in ax[1].get_ylabel()
 
 
+def test_imshow_both_orientations():
+    s = (
+        SimulatedRainbow(R=5, dt=10 * u.minute, signal_to_noise=1000)
+        .inject_transit(planet_radius=0.2)
+        .inject_systematics(amplitude=0.005)
+    )
+
+    fi, ax = plt.subplots(2, 2, constrained_layout=True, figsize=(6, 6))
+    for i, k in enumerate(["time", "wavelength"]):
+        s.plot(ax=ax[0, i], xaxis=k)
+        s.imshow(ax=ax[1, i], xaxis=k, colorbar=False)
+    plt.savefig(os.path.join(test_directory, "imshow-both-orientations.png"))
+
+
 def test_both_types_of_plot():
     N, M = 10, 20
     r = SimulatedRainbow(

--- a/chromatic/tests/test_withmodel.py
+++ b/chromatic/tests/test_withmodel.py
@@ -29,3 +29,16 @@ def test_imshow_data_with_models():
     plt.savefig(os.path.join(test_directory, "imshow-data-with-model.pdf"))
     s.imshow_data_with_models(models=["systematics_model", "planet_model"], cmap="gray")
     plt.savefig(os.path.join(test_directory, "imshow-data-with-model-components.pdf"))
+
+    s.imshow_data_with_models(models=["systematics_model", "planet_model"], cmap="gray")
+    s.imshow_data_with_models(
+        models=["systematics_model", "planet_model"], cmap="gray", label=False
+    )
+    s.imshow_data_with_models(
+        models=["systematics_model", "planet_model"],
+        cmap="gray",
+        labelkw=dict(color="red"),
+    )
+    s.imshow_data_with_models(
+        models=["systematics_model", "planet_model"], cmap="gray", label="outside"
+    )

--- a/chromatic/version.py
+++ b/chromatic/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 
 def version():

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     install_requires=[
         "numpy",
         "scipy",
-        "matplotlib>=3.0",
+        "matplotlib>=3.5",
         "astropy>=4.0",
         "pandas",
         "tqdm",


### PR DESCRIPTION
The changes include:
- Add an `xaxis='time'` or `xaxis='wavelength'` option to change the orientation on the imshow plots. 
- Add `_add_panel_labels` helper to add (a), (b), (c) labels to multipanel plots. Apply this to `.imshow_data_with_models()`.
- In `.plot_quantities`, change the `data_like` keyword to `xaxis` for consistency with `.imshow` and `.plot`.
- A few tiny bug fixes to `plot_spectra` that came up while testing on new examples.