### PR TITLE
fix weird binning with `ok`; add `ok_threshold`; fix `align_wavelengths`

### DIFF
--- a/chromatic/rainbows/actions/align_wavelengths.py
+++ b/chromatic/rainbows/actions/align_wavelengths.py
@@ -37,7 +37,7 @@ def _create_shared_wavelength_axis(
         Should we make some plots showing how the shared wavelength
         axis compares to the original input wavelength axes?
     """
-    w = rainbow.fluxlike["wavelength"]
+    w = rainbow.fluxlike["wavelength"] * 1
     w[rainbow.ok == False] = np.nan
     dw_per_time = np.gradient(w, axis=rainbow.waveaxis)
     R_per_time = w / dw_per_time
@@ -100,12 +100,36 @@ def _create_shared_wavelength_axis(
     return shared_w
 
 
-def align_wavelengths(self, **kw):
+def align_wavelengths(self, ok_threshold=1, **kw):
     """
     Use 2D wavelength information to align onto a single 1D wavelength array.
 
     Parameters
     ----------
+    ok_threshold : float
+        The numbers in the `.ok` attribute express "how OK?" each
+        data point is, ranging from 0 (not OK) to 1 (super OK).
+        In most cases, `.ok` will be binary, but there may be times
+        where it's intermediate (for example, if a bin was created
+        from some data that were not OK and some that were).
+        The `ok_threshold` parameter allows you to specify what
+        level of OK-ness for a point to go into the binning.
+        Reasonable options may include:
+            ok_threshold = 1
+                  Only data points that are perfectly OK
+                  will go into the binning. All other points
+                  will effectively be interpolated over. Flux
+                  uncertainties *should* be inflated appropriately,
+                  but it's very possible to create correlated
+                  bins next to each other if many of your ingoing
+                  data points are not perfectly OK.
+            ok_threshold = 1
+                  All data points that aren't definitely not OK
+                  will go into the binning. The OK-ness of points
+                  will propagate onward for future binning.
+            ok_threshold < 0
+                  All data points will be included in the bin.
+                  The OK-ness will propagate onward.
     wscale : str
         What kind of a new wavelength axis should be created?
         Options include:
@@ -132,7 +156,11 @@ def align_wavelengths(self, **kw):
     shared_wavelengths = self._create_shared_wavelength_axis(**kw)
 
     # bin the rainbow onto that new grid, starting from 2D wavelengths
-    shifted = self.bin(wavelength=shared_wavelengths, starting_wavelengths="2D")
+    shifted = self.bin_in_wavelength(
+        wavelength=shared_wavelengths,
+        ok_threshold=ok_threshold,
+        starting_wavelengths="2D",
+    )
 
     # append the history entry to the new Rainbow
     shifted._record_history_entry(h)

--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -427,23 +427,25 @@ class Rainbow:
             must be within 1% of each other for the wavelength
             scale to be called linear.
         """
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
 
-        # give up if there's no wavelength array
-        if self.wavelength is None:
-            return "?"
+            # give up if there's no wavelength array
+            if self.wavelength is None:
+                return "?"
 
-        # calculate difference arrays
-        w = self.wavelength.value
-        dw = np.diff(w)
-        dlogw = np.diff(np.log(w))
+            # calculate difference arrays
+            w = self.wavelength.value
+            dw = np.diff(w)
+            dlogw = np.diff(np.log(w))
 
-        # test the three options
-        if np.allclose(dw, np.median(dw), rtol=relative_tolerance):
-            self.metadata["wscale"] = "linear"
-        elif np.allclose(dlogw, np.median(dlogw), rtol=relative_tolerance):
-            self.metadata["wscale"] = "log"
-        else:
-            self.metadata["wscale"] = "?"
+            # test the three options
+            if np.allclose(dw, np.median(dw), rtol=relative_tolerance):
+                self.metadata["wscale"] = "linear"
+            elif np.allclose(dlogw, np.median(dlogw), rtol=relative_tolerance):
+                self.metadata["wscale"] = "log"
+            else:
+                self.metadata["wscale"] = "?"
 
     def _guess_tscale(self, relative_tolerance=0.01):
         """
@@ -458,26 +460,28 @@ class Rainbow:
             the times effectively uniform, or for us to treat
             them more carefully as an irregular or gappy grid.
         """
-
-        # give up if there's no time array
-        if self.time is None:
-            return "?"
-
-        # calculate difference arrays
-        t = self.time.value
-        dt = np.diff(t)
         with warnings.catch_warnings():
-            # (don't complain about negative time)
             warnings.simplefilter("ignore")
-            dlogt = np.diff(np.log(t))
 
-        # test the three options
-        if np.allclose(dt, np.median(dt), rtol=relative_tolerance):
-            self.metadata["tscale"] = "linear"
-        elif np.allclose(dlogt, np.median(dlogt), rtol=relative_tolerance):
-            self.metadata["tscale"] = "log"
-        else:
-            self.metadata["tscale"] = "?"
+            # give up if there's no time array
+            if self.time is None:
+                return "?"
+
+            # calculate difference arrays
+            t = self.time.value
+            dt = np.diff(t)
+            with warnings.catch_warnings():
+                # (don't complain about negative time)
+                warnings.simplefilter("ignore")
+                dlogt = np.diff(np.log(t))
+
+            # test the three options
+            if np.allclose(dt, np.median(dt), rtol=relative_tolerance):
+                self.metadata["tscale"] = "linear"
+            elif np.allclose(dlogt, np.median(dlogt), rtol=relative_tolerance):
+                self.metadata["tscale"] = "log"
+            else:
+                self.metadata["tscale"] = "?"
 
     @property
     def name(self):
@@ -519,7 +523,10 @@ class Rainbow:
         """
         The 2D array of whether data is OK (row = wavelength, col = time).
         """
-        return self.fluxlike.get("ok", np.ones_like(self.flux).astype(bool))
+        ok = self.fluxlike.get("ok", np.ones_like(self.flux).astype(bool))
+        if self.flux is not None:
+            ok *= np.isfinite(self.flux)
+        return ok
 
     @property
     def _time_label(self):
@@ -654,26 +661,6 @@ class Rainbow:
         """
         return np.prod(self.shape)
 
-    def is_ok(self):
-        """
-        Create a flux-like array indicating which data are OK,
-        meaning they are both finite and not marked somewhere
-        ask being bad.
-
-        Returns
-        -------
-        ok : boolean array
-            Fluxlike array of Trues and Falses indicating
-            which data entries are OK.
-        """
-
-        ok = np.isfinite(self.flux)
-        try:
-            ok *= self.fluxlike["ok"]
-        except KeyError:
-            pass
-        return ok
-
     def _validate_core_dictionaries(self):
         """
         Do some simple checks to make sure this Rainbow
@@ -725,6 +712,9 @@ class Rainbow:
                     """
                     warnings.warn(message)
 
+        if "ok" in self.fluxlike:
+            is_nan = np.isnan(self.fluxlike["ok"])
+            self.fluxlike["ok"][is_nan] = 0
         self._sort()
 
     def _make_sure_wavelength_edges_are_defined(self):

--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -523,7 +523,10 @@ class Rainbow:
         """
         The 2D array of whether data is OK (row = wavelength, col = time).
         """
-        ok = self.fluxlike.get("ok", np.ones_like(self.flux).astype(bool))
+        ok = self.fluxlike.get("ok", np.ones(self.shape).astype(bool))
+        ok *= self.wavelike.get("ok", np.ones(self.nwave).astype(bool))[:, np.newaxis]
+        ok *= self.timelike.get("ok", np.ones(self.ntime).astype(bool))[np.newaxis, :]
+
         if self.flux is not None:
             ok *= np.isfinite(self.flux)
         return ok

--- a/chromatic/rainbows/visualizations/imshow.py
+++ b/chromatic/rainbows/visualizations/imshow.py
@@ -119,14 +119,27 @@ def imshow(
         tlower, tupper = -0.5, self.ntime - 0.5
         tlabel = "Time Index"
 
+    def get_2D(k):
+        """
+        A small helper to get a 2D quantity. This is a bit of
+        a kludge to help with weird cases of duplicate keys
+        (for example where 'wavelength' might appear in both
+        `wavelike` and `fluxlike`).
+        """
+        z = self.get(k)
+        if np.shape(z) == self.shape:
+            return z
+        else:
+            return self.fluxlike.get(k, None)
+
     if xaxis.lower()[0] == "t":
         self._imshow_extent = [tlower, tupper, wupper, wlower]
         xlabel, ylabel = tlabel, wlabel
-        z = self.get(quantity)
+        z = get_2D(quantity)
     elif xaxis.lower()[0] == "w":
         self._imshow_extent = [wlower, wupper, tupper, tlower]
         xlabel, ylabel = wlabel, tlabel
-        z = self.get(quantity).T
+        z = get_2D(quantity).T
     else:
         warnings.warn(
             "Please specify either `xaxis='time'` or `xaxis='wavelength'` for `.plot()`"

--- a/chromatic/rainbows/wavelike_summaries/typical_uncertainty.py
+++ b/chromatic/rainbows/wavelike_summaries/typical_uncertainty.py
@@ -3,7 +3,7 @@ from ...imports import *
 __all__ = ["get_typical_uncertainty"]
 
 
-def get_typical_uncertainty(self, function=np.nanmedian):
+def get_typical_uncertainty(self, function=np.nanmedian, *args, **kwargs):
     """
     Get the typical per-wavelength uncertainty.
 
@@ -13,12 +13,18 @@ def get_typical_uncertainty(self, function=np.nanmedian):
         What function should be used to choose the "typical"
         value for each wavelength? Good options are probably
         things like `np.nanmedian`, `np.median`, `np.nanmean`
-        `np.mean`
+        `np.mean`, `np.percentile`
+    args : list
+        Addition arguments will be passed to `function`
+    kw : dict
+        Additional keyword arguments will be passed to `function`
 
     Returns
     -------
     uncertainty_per_wavelength : np.array (wavelike)
         The uncertainty associated with each wavelength.
     """
-    uncertainty_per_wavelength = function(self.uncertainty, axis=self.timeaxis)
+    uncertainty_per_wavelength = function(
+        self.uncertainty, *args, axis=self.timeaxis, **kwargs
+    )
     return uncertainty_per_wavelength

--- a/chromatic/resampling.py
+++ b/chromatic/resampling.py
@@ -38,6 +38,11 @@ def calculate_bin_leftright(x):
     # left = x - xbinsize / 2.0
     # right = x + xbinsize / 2.0
 
+    # weird corner case!
+    if len(x) == 1:
+        left, right = np.sort([0, 2 * x[0]])
+        return np.array([left]), np.array([right])
+
     inner_edges = 0.5 * np.diff(x) + x[:-1]
     first_edge = x[0] - (inner_edges[0] - x[0])
     last_edge = x[-1] + (x[-1] - inner_edges[-1])
@@ -579,7 +584,6 @@ def bintogrid(
             ok *= np.isfinite(weights)
 
         if np.any(ok):
-            # TO-DO: check this nan handling on input arrays is OK?
             numerator = resample_while_conserving_flux(
                 xin=x_without_unit[ok],
                 yin=(y_without_unit * weights)[ok],

--- a/chromatic/tests/setup_tests.py
+++ b/chromatic/tests/setup_tests.py
@@ -2,7 +2,6 @@ import os, pytest
 import matplotlib.pyplot as plt
 
 test_directory = "examples/"
-plt.ioff()
 
 try:
     os.mkdir(test_directory)

--- a/chromatic/tests/test_binning.py
+++ b/chromatic/tests/test_binning.py
@@ -215,23 +215,6 @@ def test_binning_to_one():
             assert bt.ntime == 1
 
 
-def test_bin_with_not_ok_data():
-    for ok_fraction in [0, 0.01, 0.5, 0.99, 1]:
-        a = SimulatedRainbow(dt=2 * u.minute, dw=0.2 * u.micron).inject_transit()
-        a.ok = np.random.uniform(size=a.shape) < ok_fraction
-
-        if ok_fraction == 0:
-            with pytest.raises(RuntimeError):
-                should_fal = a.bin(dw=0.7 * u.micron, dt=20 * u.minute, ok_threshold=1)
-            continue
-
-        cautious = a.bin(dw=0.7 * u.micron, dt=20 * u.minute, ok_threshold=1)
-        carefree = a.bin(dw=0.7 * u.micron, dt=20 * u.minute, ok_threshold=0)
-        assert np.all((cautious.ok == 1) | (cautious.ok == 0))
-        if np.any(a.ok == 0):
-            assert np.any((carefree.ok != 1) & (carefree.ok != 0))
-
-
 def test_integrated_wrappers():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")

--- a/chromatic/tests/test_binning.py
+++ b/chromatic/tests/test_binning.py
@@ -215,6 +215,23 @@ def test_binning_to_one():
             assert bt.ntime == 1
 
 
+def test_bin_with_not_ok_data():
+    for ok_fraction in [0, 0.01, 0.5, 0.99, 1]:
+        a = SimulatedRainbow(dt=2 * u.minute, dw=0.2 * u.micron).inject_transit()
+        a.ok = np.random.uniform(size=a.shape) < ok_fraction
+
+        if ok_fraction == 0:
+            with pytest.raises(RuntimeError):
+                should_fal = a.bin(dw=0.7 * u.micron, dt=20 * u.minute, ok_threshold=1)
+            continue
+
+        cautious = a.bin(dw=0.7 * u.micron, dt=20 * u.minute, ok_threshold=1)
+        carefree = a.bin(dw=0.7 * u.micron, dt=20 * u.minute, ok_threshold=0)
+        assert np.all((cautious.ok == 1) | (cautious.ok == 0))
+        if np.any(a.ok == 0):
+            assert np.any((carefree.ok != 1) & (carefree.ok != 0))
+
+
 def test_integrated_wrappers():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")

--- a/chromatic/tests/test_ok.py
+++ b/chromatic/tests/test_ok.py
@@ -1,0 +1,30 @@
+from ..rainbows import *
+from .setup_tests import *
+
+
+def test_ok_rows_and_columns():
+    s = SimulatedRainbow()
+    s.wavelike["ok"] = np.arange(s.nwave) > 10
+    s.timelike["ok"] = np.arange(s.ntime) > 5
+    s.fluxlike["ok"] = np.ones(s.shape)
+    assert s.ok[0, 0] == 0
+    assert s.ok[-1, -1] == 1
+    assert np.all(s.ok[:10, :] == 0)
+    assert np.all(s.ok[:, :5] == 0)
+
+
+def test_bin_with_not_ok_data():
+    for ok_fraction in [0, 0.01, 0.5, 0.99, 1]:
+        a = SimulatedRainbow(dt=2 * u.minute, dw=0.2 * u.micron).inject_transit()
+        a.ok = np.random.uniform(size=a.shape) < ok_fraction
+
+        if ok_fraction == 0:
+            with pytest.raises(RuntimeError):
+                should_fal = a.bin(dw=0.7 * u.micron, dt=20 * u.minute, ok_threshold=1)
+            continue
+
+        cautious = a.bin(dw=0.7 * u.micron, dt=20 * u.minute, ok_threshold=1)
+        carefree = a.bin(dw=0.7 * u.micron, dt=20 * u.minute, ok_threshold=0)
+        assert np.all((cautious.ok == 1) | (cautious.ok == 0))
+        if np.any(a.ok == 0):
+            assert np.any((carefree.ok != 1) & (carefree.ok != 0))

--- a/chromatic/version.py
+++ b/chromatic/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 
 
 def version():


### PR DESCRIPTION
This draft attempts to fix the problem @will-waalkes discovered in #113 , where NRES spectra could either be binned or have their wavelengths aligned but not both. The fundamental problem was that when `ok` (== 1 if good, == 0 if bad) got interpolated for binning (which happens as part of `.align_wavelengths`), it was behaving weirdly (being converted to float and back to bool, with some information getting lost along the way). Now there is an `ok_threshold` keyword argument for `.align_wavelengths` and the `.bin` functions that specifies how to treat bad data. `ok_threshold = 1` will entirely ignore data that's not perfect and attempt to interpolate over it, `ok_threshold = 0` will include bad data when binning but continue to keep track of its `ok`-ness for future use. 