### PR TITLE
add `.pcolormesh` to `Rainbow` and documentation

### DIFF
--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -934,6 +934,7 @@ class Rainbow:
     # import visualizations that can act on Rainbows
     from .visualizations import (
         imshow,
+        pcolormesh,
         plot_lightcurves,
         _setup_animate_lightcurves,
         animate_lightcurves,

--- a/chromatic/rainbows/visualizations/__init__.py
+++ b/chromatic/rainbows/visualizations/__init__.py
@@ -7,3 +7,4 @@ from .interactive import *
 from .plot_spectra import *
 from .plot import *
 from .utilities import *
+from .pcolormesh import *

--- a/chromatic/rainbows/visualizations/imshow.py
+++ b/chromatic/rainbows/visualizations/imshow.py
@@ -15,7 +15,8 @@ def imshow(
     **kw,
 ):
     """
-    imshow flux as a function of time (x = time, y = wavelength, color = flux).
+    Paint a 2D image of flux as a function of time and wavelength,
+    using `plt.imshow` where pixels will have constant size.
 
     Parameters
     ----------

--- a/chromatic/rainbows/visualizations/pcolormesh.py
+++ b/chromatic/rainbows/visualizations/pcolormesh.py
@@ -1,0 +1,111 @@
+from ...imports import *
+from ...resampling import leftright_to_edges
+
+__all__ = ["pcolormesh"]
+
+
+def pcolormesh(
+    self,
+    ax=None,
+    quantity="flux",
+    xaxis="time",
+    w_unit="micron",
+    t_unit="day",
+    colorbar=True,
+    **kw,
+):
+    """
+    Paint a 2D image of flux as a function of time and wavelength,
+    using `plt.pcolormesh` where pixels can transform based on their edges.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        The axes into which to make this plot.
+    quantity : str
+        The fluxlike quantity to imshow.
+        (Must be a key of `rainbow.fluxlike`).
+    w_unit : str, astropy.unit.Unit
+        The unit for plotting wavelengths.
+    t_unit : str, astropy.unit.Unit
+        The unit for plotting times.
+    colorbar : bool
+        Should we include a colorbar?
+    kw : dict
+        All other keywords will be passed on to `plt.pcolormesh`,
+        so you can have more detailed control over the plot
+        appearance. Common keyword arguments might include:
+        `[cmap, norm, alpha, vmin, vmax]` (and more)
+        More details are available at
+        https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.pcolormesh.html
+    """
+
+    # self.speak(f'imshowing')
+    if ax is None:
+        ax = plt.subplot()
+
+    # get units
+    w_unit, t_unit = u.Unit(w_unit), u.Unit(t_unit)
+
+    # make sure some wavelength and time edges are defined
+    self._make_sure_wavelength_edges_are_defined()
+    self._make_sure_time_edges_are_defined()
+
+    # set up the wavelength and time edges
+    w_edges = leftright_to_edges(
+        self.wavelength_lower.to_value(w_unit), self.wavelength_upper.to_value(w_unit)
+    )
+    t_edges = leftright_to_edges(
+        self.time_lower.to_value(t_unit), self.time_upper.to_value(t_unit)
+    )
+
+    wlabel = f"{self._wave_label} ({w_unit.to_string('latex_inline')})"
+    tlabel = f"{self._time_label} ({t_unit.to_string('latex_inline')})"
+
+    def get_2D(k):
+        """
+        A small helper to get a 2D quantity. This is a bit of
+        a kludge to help with weird cases of duplicate keys
+        (for example where 'wavelength' might appear in both
+        `wavelike` and `fluxlike`).
+        """
+        z = self.get(k)
+        if np.shape(z) == self.shape:
+            return z
+        else:
+            return self.fluxlike.get(k, None)
+
+    if xaxis.lower()[0] == "t":
+        x, y = t_edges, w_edges
+        xlabel, ylabel = tlabel, wlabel
+        z = get_2D(quantity)
+    elif xaxis.lower()[0] == "w":
+        x, y = w_edges, t_edges
+        xlabel, ylabel = wlabel, tlabel
+        z = get_2D(quantity).T
+    else:
+        warnings.warn(
+            "Please specify either `xaxis='time'` or `xaxis='wavelength'` for `.plot()`"
+        )
+
+    # define some default keywords
+    pcolormesh_kw = dict(shading="flat")
+    pcolormesh_kw.update(**kw)
+    with quantity_support():
+        plt.sca(ax)
+        plt.pcolormesh(
+            x,
+            y,
+            z,
+            **pcolormesh_kw,
+        )
+        plt.ylabel(ylabel)
+        plt.xlabel(xlabel)
+        if colorbar:
+            plt.colorbar(
+                ax=ax,
+                label=u.Quantity(z).unit.to_string("latex_inline"),
+            )
+        # emulate origin = upper for imshow (y starts at top)
+        plt.ylim(y[-1], y[0])
+    return ax

--- a/chromatic/tests/test_visualizations.py
+++ b/chromatic/tests/test_visualizations.py
@@ -192,3 +192,21 @@ def test_both_types_of_plot():
 def test_add_labels_to_panels():
     fi, ax = plt.subplots(3, 3)
     _add_panel_labels(ax, preset="inside", color="blue")
+
+
+def test_pcolormesh():
+    s = (
+        SimulatedRainbow(R=10, dt=10 * u.minute)
+        .inject_transit()
+        .inject_noise(signal_to_noise=1000)
+    )
+    fi, ax = plt.subplots(2, 2, constrained_layout=True, figsize=(8, 5))
+    s.imshow(ax=ax[0, 0])
+    plt.title("imshow")
+    s.pcolormesh(ax=ax[0, 1])
+    plt.title("pcolormesh")
+    plt.yscale("log")
+    b = s.bin(dw=0.5 * u.micron)
+    b.imshow(ax=ax[1, 0])
+    b.pcolormesh(ax=ax[1, 1])
+    plt.savefig(os.path.join(test_directory, "test-pcolormesh-vs-imshow.png"))

--- a/docs/visualizing.ipynb
+++ b/docs/visualizing.ipynb
@@ -29,12 +29,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s = SimulatedRainbow(dw=0.1 * u.micron, signal_to_noise=300, dt=4 * u.minute)\n",
+    "s = SimulatedRainbow(dw=0.1 * u.micron, dt=4 * u.minute)\n",
     "\n",
     "# inject an interesting transit signal\n",
     "theta = np.linspace(0, 2 * np.pi, s.nwave)\n",
-    "planet_radius = np.sin(theta) * 0.025 + 0.15\n",
-    "r = s.inject_transit(planet_radius=planet_radius)"
+    "planet_radius = np.sin(theta) * 0.05 + 0.2\n",
+    "r = s.inject_transit(planet_radius=planet_radius).inject_noise()"
    ]
   },
   {
@@ -101,6 +101,41 @@
    "outputs": [],
    "source": [
     "r.imshow_quantities()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 🌈.pcolormesh()\n",
+    "\n",
+    "Display the flux as an image, with each pixel representing the flux for a particular time and wavelength, but using `plt.pcolormesh` which allows pixels to stretch and squeeze based on the actual locations of their edges. Use `.imshow()` if you want wavelength/time bins to appear with the uniform sizes; use `.pcolormesh()` if you want to allow them to transform with the axes or non-uniform edges."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.pcolormesh();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.pcolormesh()\n",
+    "plt.yscale(\"log\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It accepts most of the same options as `.imshow()`."
    ]
   },
   {


### PR DESCRIPTION
The changes include:
- add `.pcolormesh` as a new visualization option. It behaves very similarly to `.imshow`, but it (a) allows the wavelength and time bins to be non-uniform and (b) stretches appropriately when axes are switched between `log` and `linear` scales. 
- add example using `.pcolormesh` to documentation