### PR TITLE
add `*_edges` and `n*` binning options to documentation

### DIFF
--- a/docs/actions.ipynb
+++ b/docs/actions.ipynb
@@ -53,7 +53,7 @@
     "    It has a {x.nwave} wavelengths and {x.ntime} times. \n",
     "\n",
     "    Its 5 first wavelengths:{np.round(x.wavelength[:5], 2)}\n",
-    "    Its 5 first times:{np.round(x.time[:5], 2)}\n",
+    "    Its 5 first times:{np.round(x.time[:5].to('hour'), 2)}\n",
     "    \"\"\"\n",
     "    )"
    ]
@@ -74,7 +74,9 @@
     "To bin in **wavelength**, it can take the following inputs:\n",
     "- `dw=` to bin in wavelength to a particular $d\\lambda$ width. This will create a linear grid in wavelength.\n",
     "- `R=` to bin in wavelength to particular $R = \\lambda/d\\lambda$. This will create a logarithmic grid in wavelength.\n",
-    "- `wavelength=` to bin to any custom wavelength grid. *(Right now, this tries to make a good guess for the edges of the bins based on their centers; we should probably implement a more straightfoward way to insert and track specifc left and right bin edges.)*"
+    "- `wavelength=` to bin to any custom wavelength grid specified by its centers; the edges will be guessed from the spacing between these edges. \n",
+    "- `wavelength_edges=` to bin to any custom wavelength grid specified by its edges; the centers will be guessed as the midpoints between these edges. (The number of binned wavelengths will be 1 fewer than the number of edges.)\n",
+    "- `nwavelengths=` to bin by a fixed number of adjacent wavelengths (as in \"bin every N wavelengths together\"), starting from the first wavelength. "
    ]
   },
   {
@@ -103,7 +105,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "b = r.bin(wavelength=np.linspace(1, 2, 4) * u.micron)\n",
+    "b = r.bin(wavelength=np.linspace(1, 2, 6) * u.micron)\n",
+    "summarize(b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "b = r.bin(wavelength_edges=np.linspace(1, 2, 6) * u.micron)\n",
+    "summarize(b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "b = r.bin(nwavelengths=10)\n",
     "summarize(b)"
    ]
   },
@@ -113,7 +135,9 @@
    "source": [
     "To bin in **time**, it can take the following inputs:\n",
     "- `dt=` to bin in time to a particular $dt$ width. This will create a linear grid in time.\n",
-    "- `time=` to bin to any custom time grid. *(Right now, this tries to make a good guess for the edges of the bins based on their centers; we should probably implement a more straightfoward way to insert and track specifc left and right bin edges.)*"
+    "- `time=` to bin to any custom time grid specified by its centers; the edges will be guessed from the spacing between these edges. \n",
+    "- `time_edges=` to bin to any custom time grid specified by its edges; the centers will be guessed as the midpoints between these edges. (The number of binned times will be 1 fewer than the number of edges.)\n",
+    "- `ntimes=` to bin by a fixed number of adjacent times (as in \"bin every N times together\"), starting from the first time. "
    ]
   },
   {
@@ -132,7 +156,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "b = r.bin(time=np.linspace(-1, 1, 5) * u.hour)\n",
+    "b = r.bin(time=np.linspace(-1, 1, 6) * u.hour)\n",
+    "summarize(b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "b = r.bin(time_edges=np.linspace(-1, 1, 6) * u.hour)\n",
+    "summarize(b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "b = r.bin(ntimes=10)\n",
     "summarize(b)"
    ]
   },
@@ -159,7 +203,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fi, ax = plt.subplots(2, 1, sharex=True, figsize=(6, 6))\n",
+    "fi, ax = plt.subplots(1, 2, sharex=True, figsize=(8, 3), constrained_layout=True)\n",
     "r.imshow(ax=ax[0], vmin=0.98, vmax=1.02)\n",
     "plt.title(\"Unbinned\")\n",
     "plt.xlabel(\"\")\n",


### PR DESCRIPTION
The changes include:
- add documentation for `.bin()` keyword options `wavelength_edges`, `time_edges`, `nwavelengths`, `ntimes`