### PR TITLE
add some checks to avoid arrays pointing to same data

### DIFF
--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -364,11 +364,11 @@ class Rainbow:
             The quantity to sort.
         """
         if np.shape(v) == self.shape:
-            self.fluxlike[k] = v
+            self.fluxlike[k] = v * 1
         elif np.shape(v) == (self.nwave,):
-            self.wavelike[k] = v
+            self.wavelike[k] = v * 1
         elif np.shape(v) == (self.ntime,):
-            self.timelike[k] = v
+            self.timelike[k] = v * 1
         else:
             raise ValueError("'{k}' doesn't fit anywhere!")
 
@@ -615,13 +615,13 @@ class Rainbow:
             if key in self._core_dictionaries:
                 raise ValueError("Trying to set a core dictionary.")
             elif key == "wavelength":
-                self.wavelike["wavelength"] = value
+                self.wavelike["wavelength"] = value * 1
                 self._validate_core_dictionaries()
             elif key == "time":
-                self.timelike["time"] = value
+                self.timelike["time"] = value * 1
                 self._validate_core_dictionaries()
             elif key in ["flux", "uncertainty", "ok"]:
-                self.fluxlike[key] = value
+                self.fluxlike[key] = value * 1
                 self._validate_core_dictionaries()
             elif isinstance(value, str):
                 self.metadata[key] = value
@@ -726,6 +726,16 @@ class Rainbow:
         if "ok" in self.fluxlike:
             is_nan = np.isnan(self.fluxlike["flux"])
             self.fluxlike["ok"][is_nan] = 0
+
+        # make sure no arrays are accidentally pointed to each other
+        # (if they are, sorting will get really messed up!)
+        for d in ["fluxlike", "wavelike", "timelike"]:
+            core_dictionary = self.get(d)
+            for k1, v1 in core_dictionary.items():
+                for k2, v2 in core_dictionary.items():
+                    if k1 != k2:
+                        assert v1 is not v2
+
         self._sort()
 
     def _make_sure_wavelength_edges_are_defined(self):

--- a/chromatic/rainbows/readers/atoca.py
+++ b/chromatic/rainbows/readers/atoca.py
@@ -83,7 +83,7 @@ def from_atoca(rainbow, filepath, order=1):
         if i_file == 0:
             # Create time axis
             times, nints = get_time_axis(hdu_list["PRIMARY"].header)
-            rainbow.timelike["time"] = times
+            rainbow.timelike["time"] = times * 1
 
         # Loop over all extensions.
         for i in range(1, len(hdu_list)):
@@ -117,10 +117,10 @@ def from_atoca(rainbow, filepath, order=1):
             )
         elif quantity == "WAVELENGTH":
             rainbow.wavelike["wavelength"] = (
-                np.nanmedian(quantities[quantity], axis=0) * u.micron
+                np.nanmedian(quantities[quantity], axis=0) * u.micron * 1
             )
         else:
-            rainbow.fluxlike[quantity] = quantities[quantity].T
+            rainbow.fluxlike[quantity] = quantities[quantity].T * 1
 
     # Warn user if the number of unpacked integrations doesn't match the
     # expected amount.

--- a/chromatic/rainbows/readers/coloumbe.py
+++ b/chromatic/rainbows/readers/coloumbe.py
@@ -65,7 +65,7 @@ def from_coloumbe(rainbow, filepath, order=1):
                 # pull out a wavelength grid (assuming it'll stay constant)
                 wavelength_unit = u.Unit(hdu[e].columns["wavelength"].unit)
                 rainbow.wavelike["wavelength"] = (
-                    hdu[e].data["wavelength"] * wavelength_unit
+                    hdu[e].data["wavelength"] * wavelength_unit * 1
                 )
 
                 # set up the fluxlike quantities
@@ -86,14 +86,14 @@ def from_coloumbe(rainbow, filepath, order=1):
                         column_units[c] = 1
 
                     # populate the fluxlike dictionary with the empty array
-                    rainbow.fluxlike[c] = this_quantity
+                    rainbow.fluxlike[c] = this_quantity * 1
 
             for column in hdu[e].columns:
 
                 # get a lower case name for the unit
                 c = column.name.lower()
                 rainbow.fluxlike[c][:, integration_counter - 1] = (
-                    hdu[e].data[c] * column_units[c]
+                    hdu[e].data[c] * column_units[c] * 1
                 )
 
             # increment the running integration total

--- a/chromatic/rainbows/readers/dossantos.py
+++ b/chromatic/rainbows/readers/dossantos.py
@@ -87,12 +87,12 @@ def from_dossantos(rainbow, filepath):
 
     # populate a 1D array of wavelengths (with astropy units of length)
     wavelength = spectra[0]["wavelength"] * u.micron
-    rainbow.wavelike["wavelength"] = wavelength
+    rainbow.wavelike["wavelength"] = wavelength * 1
 
     # populate a 1D array of times (with astropy units of time)
     times = np.arange(len(spectra)) * u.minute
     warnings.warn("The times are totally made up!")
-    rainbow.timelike["time"] = times
+    rainbow.timelike["time"] = times * 1
 
     # populate a 2D (row = wavelength, col = array of fluxes
     flux = np.zeros((len(wavelength), len(times)))
@@ -102,5 +102,5 @@ def from_dossantos(rainbow, filepath):
         flux[:, k] = spectra[k]["flux"]
         uncertainty[:, k] = spectra[k]["flux_error"]
 
-    rainbow.fluxlike["flux"] = flux
-    rainbow.fluxlike["uncertainty"] = uncertainty
+    rainbow.fluxlike["flux"] = flux * 1
+    rainbow.fluxlike["uncertainty"] = uncertainty * 1

--- a/chromatic/rainbows/readers/espinoza.py
+++ b/chromatic/rainbows/readers/espinoza.py
@@ -35,13 +35,13 @@ def from_espinoza(rainbow, filepath):
     wavelengths = np.load(wavelengths_filename)
 
     # populate a 1D array of wavelengths (with astropy units of length)
-    rainbow.wavelike["wavelength"] = wavelengths * u.micron
+    rainbow.wavelike["wavelength"] = wavelengths * u.micron * 1
 
     # populate a 1D array of times (with astropy units of time)
     times = np.arange(spectra.shape[0]) * u.minute
     warnings.warn("The times are totally made up!")
-    rainbow.timelike["time"] = times
+    rainbow.timelike["time"] = times * 1
 
     # populate a 2D (row = wavelength, col = array of fluxes
-    rainbow.fluxlike["flux"] = spectra[:, 0, :].T
-    rainbow.fluxlike["uncertainty"] = spectra[:, 1, :].T
+    rainbow.fluxlike["flux"] = spectra[:, 0, :].T * 1
+    rainbow.fluxlike["uncertainty"] = spectra[:, 1, :].T * 1

--- a/chromatic/rainbows/readers/eureka.py
+++ b/chromatic/rainbows/readers/eureka.py
@@ -25,12 +25,12 @@ def eureadka_txt(filename):
         except KeyError:
             pass
     timelike = {}
-    timelike["time"] = t * u.day
+    timelike["time"] = t * u.day * 1
 
     # figure out a wavelength array
     w = np.unique(data["wave_1d"])
     wavelike = {}
-    wavelike["wavelength"] = w * u.micron
+    wavelike["wavelength"] = w * u.micron * 1
 
     # populate the fluxlike quantities
     fluxlike = {}
@@ -47,8 +47,8 @@ def eureadka_txt(filename):
             indices_for_this_wavelength = i_wavelength + i_time * len(w)
             fluxlike[k][i_wavelength, i_time] = data[k][indices_for_this_wavelength]
 
-    fluxlike["flux"] = fluxlike["optspec"]
-    fluxlike["uncertainty"] = fluxlike["opterr"]
+    fluxlike["flux"] = fluxlike["optspec"] * 1
+    fluxlike["uncertainty"] = fluxlike["opterr"] * 1
 
     return wavelike, timelike, fluxlike
 

--- a/chromatic/rainbows/readers/feinstein.py
+++ b/chromatic/rainbows/readers/feinstein.py
@@ -82,16 +82,16 @@ def from_feinstein(rainbow, filepath):
 
     wavelength, spectra, err = np.load(filepath, allow_pickle=True)
 
-    rainbow.wavelike["wavelength"] = wavelength * u.micron
+    rainbow.wavelike["wavelength"] = wavelength * u.micron * 1
 
     # populate a 1D array of times (with astropy units of time)
     times = np.arange(spectra.shape[0]) * u.minute
     warnings.warn("The times are totally made up!")
-    rainbow.timelike["time"] = times
+    rainbow.timelike["time"] = times * 1
 
     # populate a 2D (row = wavelength, col = array of fluxes
     flux = np.zeros((len(wavelength), len(times)))
     uncertainty = np.zeros_like(flux)
 
-    rainbow.fluxlike["flux"] = spectra.T
-    rainbow.fluxlike["uncertainty"] = err.T
+    rainbow.fluxlike["flux"] = spectra.T * 1
+    rainbow.fluxlike["uncertainty"] = err.T * 1

--- a/chromatic/rainbows/readers/nres.py
+++ b/chromatic/rainbows/readers/nres.py
@@ -70,19 +70,19 @@ def from_nres(rainbow, filepath, order=52):
             rainbow.timelike["time"] = np.zeros(ntimes) * u.day
 
         # populate a 1D array of times (with astropy units of time)
-        rainbow.timelike["time"][i] = date_bjd * u.day
+        rainbow.timelike["time"][i] = date_bjd * u.day * 1
 
         # populate a 2D (row = wavelength, col = time, value = wavelength)
-        rainbow.fluxlike["wavelength"][:, i] = wavelengths
+        rainbow.fluxlike["wavelength"][:, i] = wavelengths * 1
 
         # populate a 2D (row = wavelength, col = time) array of fluxes
-        rainbow.fluxlike["flux"][:, i] = fluxes
+        rainbow.fluxlike["flux"][:, i] = fluxes * 1
 
         # populate a 2D (row = wavelength, col = time) array of uncertainties
-        rainbow.fluxlike["uncertainty"][:, i] = errors
+        rainbow.fluxlike["uncertainty"][:, i] = errors * 1
 
         # populate a 2D (row = wavelength, col = time) array of ok
-        rainbow.fluxlike["ok"][:, i] = ok
+        rainbow.fluxlike["ok"][:, i] = ok * 1
 
     # populate a 1D array of wavelengths (with astropy units of length)
     rainbow.wavelike["wavelength"] = np.nanmedian(

--- a/chromatic/rainbows/readers/rainbow_FITS.py
+++ b/chromatic/rainbows/readers/rainbow_FITS.py
@@ -44,4 +44,4 @@ def from_rainbow_FITS(rainbow, filepath):
     for e in ["fluxlike", "wavelike", "timelike"]:
         table = Table.read(hdu_list[e])
         for k in table.colnames:
-            vars(rainbow)[e][k] = table[k].quantity
+            vars(rainbow)[e][k] = table[k].quantity * 1

--- a/chromatic/rainbows/readers/x1dints.py
+++ b/chromatic/rainbows/readers/x1dints.py
@@ -126,7 +126,7 @@ def from_x1dints(rainbow, filepath):
                 # pull out a wavelength grid (assuming it'll stay constant)
                 wavelength_unit = u.Unit(hdu[e].columns["wavelength"].unit)
                 rainbow.wavelike["wavelength"] = (
-                    hdu[e].data["wavelength"] * wavelength_unit
+                    hdu[e].data["wavelength"] * wavelength_unit * 1
                 )
 
                 # set up the fluxlike quantities
@@ -175,9 +175,9 @@ def from_x1dints(rainbow, filepath):
 
     # try to pull in the errors
     try:
-        rainbow.fluxlike["uncertainty"] = rainbow.fluxlike["flux_error"]*1
+        rainbow.fluxlike["uncertainty"] = rainbow.fluxlike["flux_error"] * 1
     except KeyError:
-        rainbow.fluxlike["uncertainty"] = rainbow.fluxlike["error"]*1
+        rainbow.fluxlike["uncertainty"] = rainbow.fluxlike["error"] * 1
 
     if rainbow.uncertainty is None:
         message = f"""


### PR DESCRIPTION
The changes include:
- a few `*1` included to make sure that new arrays get created before assigning into `fluxlike`, `wavelike`, `timelike`, to avoid two keys accidentally pointing toward the same array (which wreaks havoc with the sorting)
- a validation step that loops through all the array dictionaries and makes sure that no keys point to the same data as any other keys