### PR TITLE
change `get_measured_scatter` to default to only good data; fix units

### DIFF
--- a/chromatic/rainbows/wavelike_summaries/measured_scatter.py
+++ b/chromatic/rainbows/wavelike_summaries/measured_scatter.py
@@ -3,14 +3,22 @@ from ...imports import *
 __all__ = ["get_measured_scatter"]
 
 
-def get_measured_scatter(self, quantity="flux", method="standard-deviation"):
+def get_measured_scatter(
+    self, quantity="flux", method="standard-deviation", minimum_acceptable_ok=1e-10
+):
     """
     Get measured scatter from a chromatic rainbow.
 
     Parameters
     ----------
+    quantity : string
+        The fluxlike quantity for which we should calculate the scatter.
     method : string
         What method to use to obtain measured scatter. Current options are 'MAD', 'standard-deviation'.
+    minimum_acceptable_ok : float
+        The smallest value of `ok` that will still be included.
+        (1 for perfect data, 1e-10 for everything but terrible data, 0 for all data)
+
 
     Returns
     -------
@@ -18,22 +26,24 @@ def get_measured_scatter(self, quantity="flux", method="standard-deviation"):
         The scatter wavelike array.
     """
 
-    if method == "standard-deviation":
-        scatters = np.zeros(len(self.wavelength))
-        for i, row in enumerate(self.fluxlike[quantity]):
-            scatters[i - 1] = np.std(row)
-        return scatters
-
-    if method == "MAD":
-        scatters = median_absolute_deviation(
-            self.fluxlike[quantity].copy(), axis=1, scale="normal"
-        )  # Setting the scale 'normal' is like * 1.48
-        return scatters
-
-    else:
+    if method not in ["standard-deviation", "MAD"]:
         warnings.warn(
             f"""
         '{method}' is not an available method.
         Please choose from ['MAD', 'standard-deviation'].
         """
         )
+    scatters = np.zeros(self.nwave)
+    for i in range(self.nwave):
+        x, y, sigma = self.get_ok_data_for_wavelength(
+            i, y=quantity, minimum_acceptable_ok=minimum_acceptable_ok
+        )
+        if u.Quantity(y).unit == u.Unit(""):
+            y_value, y_unit = y, 1
+        else:
+            y_value, y_unit = y.value, y.unit
+        if method == "standard-deviation":
+            scatters[i] = np.std(y_value)
+        elif method == "MAD":
+            scatters[i] = median_absolute_deviation(y_value, scale="normal")
+    return scatters * y_unit

--- a/chromatic/version.py
+++ b/chromatic/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.10"
+__version__ = "0.2.11"
 
 
 def version():

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         "astraeus @ git+https://github.com/kevin218/Astraeus@main",
     ],
     # what version of Python is required?
-    python_requires=">=3.8",  # f-strings are introduced in 3.6!
+    python_requires=">=3.7",  # f-strings are introduced in 3.6!
     # requirements in `key` will install with `pip install chromatic-lightcurves[key]`
     extras_require={
         "develop": [


### PR DESCRIPTION
This pull request:
- switches `get_measured_scatter` to default to providing measurements only for data points that are marked as `ok`
- allows options for the method to propagate through `plot_noise_comparison`