### PR TITLE
relax install requirements to make work with colab + fix uncertainty bug

### DIFF
--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -26,7 +26,7 @@ class Rainbow:
     _keys_that_respond_to_math = ["flux"]
 
     # which keys get uncertainty weighting during binning
-    _keys_that_get_uncertainty_weighting = ["flux"]
+    _keys_that_get_uncertainty_weighting = ["flux", "uncertainty"]
 
     def __init__(
         self,

--- a/chromatic/rainbows/withmodel.py
+++ b/chromatic/rainbows/withmodel.py
@@ -13,7 +13,7 @@ class RainbowWithModel(Rainbow):
     _keys_that_respond_to_math = ["flux", "model"]
 
     # which keys get uncertainty weighting during binning
-    _keys_that_get_uncertainty_weighting = ["flux", "model"]
+    _keys_that_get_uncertainty_weighting = ["flux", "model", "uncertainty"]
 
     @property
     def residuals(self):

--- a/chromatic/version.py
+++ b/chromatic/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 
 def version():

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         "numpy",
         "scipy",
         "matplotlib>=3.5",
-        "astropy>=5.0",
+        "astropy>=4.0",
         "pandas",
         "tqdm",
         "batman-package>=2.4.9",


### PR DESCRIPTION
This pull request:
- relaxes astropy 5 down to astropy 4, so that install with python 3.7 works, so that installation into a colab notebook will work
- fix major bug where uncertainties didn't bin down