### PR TITLE
tiny fix to NRES reader

### DIFF
--- a/chromatic/rainbows/readers/nres.py
+++ b/chromatic/rainbows/readers/nres.py
@@ -63,7 +63,7 @@ def from_nres(rainbow, filepath, order=52):
         if i == 0:
             ntimes = len(filenames)
             nwaves = len(wavelengths)
-            for k in ["wavelength", "flux", "uncertainty", "ok"]:
+            for k in ["wavelength_2d", "flux", "uncertainty", "ok"]:
                 rainbow.fluxlike[k] = np.zeros((nwaves, ntimes))
             rainbow.fluxlike["wavelength_2d"] *= u.micron
             rainbow.fluxlike["ok"] = rainbow.fluxlike["ok"].astype(np.bool)


### PR DESCRIPTION
In supporting some other readers/writers, we needed to get rid of the possibility of colliding variable names between `fluxlike` and `wavelike`, so the 2D wavelengths got switched to `wavelength_2d`, but apparently not anywhere. This *might* have fixed the problem, @will-waalkes ?