### PR TITLE
fix `get_phoenix_photons` bug and add documentation for related tools

### DIFF
--- a/chromatic/spectra/phoenix.py
+++ b/chromatic/spectra/phoenix.py
@@ -970,7 +970,7 @@ class PHOENIXLibrary:
                 timings["get interpolated spectrum"].append(dt)
 
                 # how long does it take to retrieve a spectrum on a particular wavelength grid
-                wavelength = np.exp(np.arange(-1, 1, 1 / R)) * u.micron
+                wavelength = np.exp(np.arange(-1, 1, 1.01 / R)) * u.micron
                 start = get_current_seconds()
                 self.get_spectrum(
                     temperature=3456, logg=5.67, metallicity=0.0, wavelength=wavelength
@@ -986,7 +986,6 @@ class PHOENIXLibrary:
         plt.legend(bbox_to_anchor=(1, 1), frameon=False)
         plt.xlabel("R = $\lambda/\Delta\lambda$")
         plt.ylabel("Time Required")
-        plt.savefig("time-required-for-phoenix-stellar-library-tools.pdf")
         return t
 
 

--- a/chromatic/spectra/phoenix.py
+++ b/chromatic/spectra/phoenix.py
@@ -772,7 +772,9 @@ class PHOENIXLibrary:
                 elif wavelength_edges is None:
                     necessary_R = self._wavelengths_to_R(wavelength)
 
-                if self.metadata.get("R", 0) < necessary_R:
+                try:
+                    assert self.metadata.get("R", 0) >= necessary_R
+                except (AttributeError, AssertionError):
                     R = self._find_smallest_R(necessary_R)
                     assert False
 

--- a/chromatic/tests/test_spectra.py
+++ b/chromatic/tests/test_spectra.py
@@ -50,3 +50,22 @@ def test_spectral_library_wavelengths(cmap=one2another("indigo", "tomato"), N=5)
     plt.savefig(
         os.path.join(test_directory, "test-spectral-library-custom_wavelengths.png")
     )
+
+
+def test_spectral_library_loads_correct_R():
+    for i in range(2):
+        w = np.linspace(0.7, 0.71, 1000) * u.micron
+        wamb, s_amb = get_phoenix_photons(
+            temperature=int(3900.0), wavelength=w, logg=4.4, metallicity=0.0
+        )
+        wspot, s_spot = get_phoenix_photons(
+            temperature=int(3100.0), wavelength=w, logg=4.4, metallicity=0.0
+        )
+        plt.figure()
+        plt.plot(wspot, s_spot)
+        plt.plot(wamb, s_amb)
+    plt.savefig(
+        os.path.join(
+            test_directory, "test-spectral-library-load-correct-resolution.png"
+        )
+    )

--- a/chromatic/version.py
+++ b/chromatic/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.10"
+__version__ = "0.3.11"
 
 
 def version():

--- a/docs/tools/binning.ipynb
+++ b/docs/tools/binning.ipynb
@@ -1,0 +1,333 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a2a36507",
+   "metadata": {},
+   "source": [
+    "# Binning Data to a New Grid\n",
+    "\n",
+    "Often we have some `y` values the correspond to a particular grid of `x` values, and we want to resample them onto a different grid of `x` values. Interpolation is one way to do this, but it won't necessarily provide reasonable averages over wiggly features. There are lots of different features we might hope for in a resampling routine, but one common one is that we'd like get the same answer when integrating between two `x` limits, whether we're using the original or the resampled grid of quantities. One way to ensure such integrals are conserved is to calculate the cumulative distribution function (= the integral up to a particular limit) of the original arrays, interpolate onto the new grid, and differentiate; [Diamond-Lowe et al. 2020](https://ui.adsabs.harvard.edu/abs/2020AJ....160...27D/abstract) provides a literature example of this algorthim being used for exoplanet transmission spectrum observations. \n",
+    "\n",
+    "For `chromatic`, the tools used to achieve this are the `bintogrid` and `bintoR` functions, which we demonstrate below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d6021a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from chromatic import bintogrid, bintoR, version\n",
+    "import numpy as np, matplotlib.pyplot as plt\n",
+    "\n",
+    "plt.matplotlib.rcParams[\"figure.figsize\"] = (8, 3)\n",
+    "plt.matplotlib.rcParams[\"figure.dpi\"] = 300"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb174f3a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "version()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c067123",
+   "metadata": {},
+   "source": [
+    "## How do we bin some input arrays?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea5b7723",
+   "metadata": {},
+   "source": [
+    "Let's create a fake input dataset with an input grid that is uniformly spaced in `x`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b87037c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "N = 100\n",
+    "x = np.linspace(1, 5, N)\n",
+    "y = x**2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84299733",
+   "metadata": {},
+   "source": [
+    "Then, let's use `bintogrid` to bin these input arrays onto a new grid with wider spacing. The results of this function are a dictionary that contain:\n",
+    "- `x` = the center of the output grid\n",
+    "- `y` = the resampled value on the output grid\n",
+    "- `x_edge_lower` = the lower edges of the output grid\n",
+    "- `x_edge_upper` = the upper edges of the output grid\n",
+    "- `N_unbinned/N_binned` = the approximate number of input bins that contributed to each output bin"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41130307",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "binned = bintogrid(x, y, dx=0.5)\n",
+    "list(binned.keys())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aaaec85d",
+   "metadata": {},
+   "source": [
+    "Let's compare the results on a plot. The resampled values line up very neatly with the "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41a714f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.scatter(x, y, alpha=0.5, label=\"input\")\n",
+    "plt.scatter(binned[\"x\"], binned[\"y\"], s=100, alpha=0.5, label=\"output\")\n",
+    "plt.xlabel(\"x\")\n",
+    "plt.ylabel(\"y\")\n",
+    "plt.legend(frameon=False);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "953cf625",
+   "metadata": {},
+   "source": [
+    "This code should work similarly even if the input arrays are non-uniform in `x`, which can be a nice way to arrange a heterogeneous dataset into something easier to work with."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "057ce116",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = np.sort(np.random.uniform(1, 5, N))\n",
+    "y = x**2\n",
+    "binned = bintogrid(x, y, dx=0.5)\n",
+    "plt.scatter(x, y, alpha=0.5, label=\"input\")\n",
+    "plt.scatter(binned[\"x\"], binned[\"y\"], s=100, alpha=0.5, label=\"output\")\n",
+    "plt.xlabel(\"x\")\n",
+    "plt.ylabel(\"y\")\n",
+    "plt.legend(frameon=False);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "600e3412",
+   "metadata": {},
+   "source": [
+    "The `bintoR` function is a wrapper around `bintogrid` that provides a quick way to bin onto logarithmic grid. In spectroscopy, it's common to want to work with wavelengths $\\lambda$ that are spaced according to a constant value of $R = \\lambda/\\Delta \\lambda = 1 / \\Delta [\\ln \\lambda]$. This quantity $R$ is often called the [spectral resolution](https://en.wikipedia.org/wiki/Spectral_resolution). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "672416ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "binned = bintoR(x, y, R=10)\n",
+    "plt.scatter(x, y, alpha=0.5, label=\"input\")\n",
+    "plt.scatter(binned[\"x\"], binned[\"y\"], s=100, alpha=0.5, label=\"output\")\n",
+    "plt.xlabel(\"x\")\n",
+    "plt.ylabel(\"y\")\n",
+    "plt.legend(frameon=False);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "377520fa",
+   "metadata": {},
+   "source": [
+    "This may seem like a weird way to define a new output grid, but its usefulness becomes apparent when we plot on logarithmic axes. It's uniform in log space!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69d08ab0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.scatter(x, y, alpha=0.5, label=\"input\")\n",
+    "plt.scatter(binned[\"x\"], binned[\"y\"], s=100, alpha=0.5, label=\"output\")\n",
+    "plt.xlabel(\"x\")\n",
+    "plt.ylabel(\"y\")\n",
+    "plt.legend(frameon=False)\n",
+    "plt.xscale(\"log\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "863870dd",
+   "metadata": {},
+   "source": [
+    "## How do we bin with uncertainties? "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd67049e",
+   "metadata": {},
+   "source": [
+    "For any real measurements, there are probably uncertainties associated with them. Both `bintogrid` and `bintoR` will try their best to propagate uncertainties by using [inverse-variance weighting](https://en.wikipedia.org/wiki/Inverse-variance_weighting) and its maximum likelihood estimate for the binned uncertainty."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3255062",
+   "metadata": {},
+   "source": [
+    "Let's look at a similar example as before, but with some uncertainties associated with each input `y` value. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bff88af6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = np.linspace(1, 5, N)\n",
+    "uncertainty = np.ones_like(x) * 5\n",
+    "y = np.random.normal(x**2, uncertainty)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a33d369a",
+   "metadata": {},
+   "source": [
+    "Let's resample it to a new grid, providing the known uncertainties on the original points. Notice that the result now also includes an `uncertainty` key."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9d46fe6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "binned = bintogrid(x, y, uncertainty, dx=0.5)\n",
+    "list(binned.keys())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1491a8f",
+   "metadata": {},
+   "source": [
+    "When we plot the input and output values, we can see that the typical output uncertainties are smaller than the typical input uncertainties, because we've effectively averaged together a few data points and therefore decreased the uncertainty for the new values. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6d45285",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kw = dict(linewidth=0, elinewidth=1, marker=\"o\", alpha=0.5, markeredgecolor=\"none\")\n",
+    "plt.errorbar(x, y, uncertainty, label=\"input\", **kw)\n",
+    "plt.errorbar(\n",
+    "    binned[\"x\"], binned[\"y\"], binned[\"uncertainty\"], label=\"output\", markersize=10, **kw\n",
+    ")\n",
+    "plt.xlabel(\"x\")\n",
+    "plt.ylabel(\"y\")\n",
+    "plt.legend(frameon=False);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a281ab48",
+   "metadata": {},
+   "source": [
+    "When we bin onto a logarithmic grid with `bintoR`, we can see that the uncertainties typically smaller for the higher values of `x`, where more input points are getting averaged together to make each output point."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d359d800",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "binned = bintoR(x, y, uncertainty, R=10)\n",
+    "plt.errorbar(x, y, uncertainty, label=\"input\", **kw)\n",
+    "plt.errorbar(\n",
+    "    binned[\"x\"], binned[\"y\"], binned[\"uncertainty\"], label=\"output\", markersize=10, **kw\n",
+    ")\n",
+    "plt.xlabel(\"x\")\n",
+    "plt.ylabel(\"y\")\n",
+    "plt.legend(frameon=False)\n",
+    "plt.xscale(\"log\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df0c7d7d",
+   "metadata": {},
+   "source": [
+    "## How do we customize the output grid? \n",
+    "\n",
+    "There are a few different options you can use to specify the exact output grid you would like. \n",
+    "\n",
+    "For `bintogrid`, the options are:\n",
+    "\n",
+    "- `nx` = the number of adjacent inputs points that should be binned together to create the output grid (for example, \"bin every 3 points together\") \n",
+    "- `dx` = the spacing for a linearly-uniform output grid \n",
+    "- `newx` = a custom output grid, referring to the centers of the new bins\n",
+    "- `newx_edges`= a custom output grid, referring to the edges of the new bins. The left and right edges of the bins will be, respectively, `newx_edges[:-1]` and `newx_edges[1:]`, so the size of the output array will be `len(newx_edges) - 1`\n",
+    "\n",
+    "For `bintoR`, the options are:\n",
+    "- `R` = the spectral resolution R=x/dx for a logarithmically-uniform output grid\n",
+    "- `xlim` = a two-element list indicating the min and max values of x for the new logarithmic output grid. If not supplied, this will center the first output bin on the first value of `x`"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/tools/colormaps.ipynb
+++ b/docs/tools/colormaps.ipynb
@@ -1,0 +1,127 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "42179ce5",
+   "metadata": {},
+   "source": [
+    "# Creating Custom Colormaps\n",
+    "\n",
+    "Colormaps provide a way to translate from numbers to colors. The `matplotlib` [colormaps](https://matplotlib.org/stable/tutorials/colors/colormaps.html) are lovely, but sometimes we just want to say \"I'd like a colormap that goes from this color to that color.\" The `one2another` colormap generator does just that."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "39a565c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from chromatic import one2another, version"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a695119f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "version()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f06ba943",
+   "metadata": {},
+   "source": [
+    "## How do we make a new colormap? \n",
+    "\n",
+    "All we need to specify is the color at the bottom and the color at the top. If we want to get really fancy, we can specify different `alpha` (= opacity) values for either of these limits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1643a4d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "one2another(\"orchid\", \"black\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6926732c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "one2another(\"black\", \"orchid\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41ded69d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "one2another(bottom=\"orchid\", top=\"orchid\", alpha_bottom=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "606c2d57",
+   "metadata": {},
+   "source": [
+    "That's it! You can use these colormaps anywhere you'd set `cmap=` in a `matplotlib` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b50f6c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np, matplotlib.pyplot as plt\n",
+    "\n",
+    "# make a custom cmap\n",
+    "my_fancy_cmap = one2another(\"orchid\", \"black\")\n",
+    "\n",
+    "# make some fake data\n",
+    "x, y = np.random.uniform(-1, 1, [2, 1000])\n",
+    "z = np.random.normal(0, 1, [10, 10])\n",
+    "\n",
+    "# use the cmap\n",
+    "fi, ax = plt.subplots(1, 2, constrained_layout=True)\n",
+    "ax[0].scatter(x, y, c=x**2 + y**2, cmap=my_fancy_cmap)\n",
+    "ax[0].axis(\"scaled\")\n",
+    "ax[1].imshow(z, cmap=my_fancy_cmap)\n",
+    "ax[1].axis(\"scaled\");"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/tools/spectra.ipynb
+++ b/docs/tools/spectra.ipynb
@@ -302,11 +302,31 @@
    "source": [
     "phoenix_library.get_cache_size()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97d110c0",
+   "metadata": {},
+   "source": [
+    "## How long do model retrievals take? \n",
+    "\n",
+    "We put some effort into speeding up the process of retrieving multiple different spectral models on similar wavelength grids. The following plot shows approximately how long different steps take on a 2020 MacBook Pro with M1 chip.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "636757f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phoenix_library.plot_time_required();"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -320,7 +340,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,8 @@ nav:
         - github.ipynb
     - Related Tools:
         - tools/spectra.ipynb
+        - tools/binning.ipynb
+        - tools/colormaps.ipynb
 theme:
   name: "material"
   features:


### PR DESCRIPTION
Changes include:
- fix the `get_phoenix_photons` bug from #182 (the fact that `.metadata` didn't exist in the library on the first pass through meant that the necessary `R` wasn't getting set properly)
- update some docstrings and function names
- update the documentation for some of the useful non-`Rainbow` related tools
- update version to 0.3.11