### PR TITLE
Small bug fixes and testing improvements.

### DIFF
--- a/chromatic/imports.py
+++ b/chromatic/imports.py
@@ -35,7 +35,7 @@ warnings.formatwarning = custom_formatwarning
 from astropy.io import ascii, fits
 from astropy.table import Table, QTable
 from astropy.time import Time
-from astropy.stats import sigma_clip
+from astropy.stats import sigma_clip, median_absolute_deviation, mad_std
 
 # import astropy.units as u
 import astropy.constants as con
@@ -45,7 +45,6 @@ from astropy.visualization import quantity_support, simple_norm
 from matplotlib.gridspec import GridSpec, GridSpecFromSubplotSpec
 
 from scipy.interpolate import interp1d
-from scipy.stats import median_abs_deviation
 
 # For modelling transits.
 import batman

--- a/chromatic/imports.py
+++ b/chromatic/imports.py
@@ -25,12 +25,24 @@ from time import time as get_current_seconds
 
 
 def custom_formatwarning(message, *args, **kwargs):
+    return f"🌈 suggestion: {textwrap.dedent(str(message))}\n"
+
+
+original_warning_format = warnings.formatwarning
+
+
+def cheerfully_suggest(*args, **kwargs):
+    warnings.formatwarning = custom_formatwarning
+    warnings.warn(*args, **kwargs)
+    warnings.formatwarning = original_warning_format
+
+
+"""def custom_formatwarning(message, *args, **kwargs):
     # ignore everything except the message
     return f"\n🌈 Warning: {textwrap.dedent(str(message))}"
 
-
 warnings.formatwarning = custom_formatwarning
-
+"""
 # astropy
 from astropy.io import ascii, fits
 from astropy.table import Table, QTable
@@ -75,7 +87,7 @@ from astropy.utils.data import download_file
 
 def download_file_with_warning(*args, **kwargs):
     if is_being_run_from_jupyter():
-        warnings.warn(
+        cheerfully_suggest(
             """
         The progress bar for this download is not being shown
         because `astropy.utils.data.download_file` is being run
@@ -119,7 +131,7 @@ def name2color(name):
         color_hex = col.cnames[name]
         return col.hex2color(color_hex)
     except KeyError:
-        warnings.warn(f"The color {name} can't be found. (Returning black.)")
+        cheerfully_suggest(f"The color {name} can't be found. (Returning black.)")
         return (0.0, 0.0, 0.0)
 
 

--- a/chromatic/rainbows/actions/align_wavelengths.py
+++ b/chromatic/rainbows/actions/align_wavelengths.py
@@ -48,14 +48,14 @@ def _create_shared_wavelength_axis(
         plt.imshow(dw_per_time, aspect="auto", vmin=0)
         plt.xlabel("Time Index")
         plt.ylabel("Wavelength Index")
-        plt.title("$\Delta\lambda$")
+        plt.title(r"$\Delta\lambda$")
         plt.colorbar(orientation="horizontal", pad=0.25)
 
         plt.sca(ax[1])
         plt.imshow(R_per_time, aspect="auto", vmin=0)
         plt.xlabel("Time Index")
         plt.ylabel("Wavelength Index")
-        plt.title("R = $\lambda/\Delta\lambda$")
+        plt.title(r"R = $\lambda/\Delta\lambda$")
         plt.colorbar(orientation="horizontal", pad=0.25)
 
     min_w, max_w = np.nanmin(w).to("micron").value, np.nanmax(w).to("micron").value
@@ -79,9 +79,9 @@ def _create_shared_wavelength_axis(
             label=f"{supersampling}x(shared)",
             marker=".",
         )
-        plt.title("$\Delta\lambda$")
+        plt.title(r"$\Delta\lambda$")
         plt.xlabel(f"Wavelength ({w.unit})")
-        plt.ylabel("$\Delta\lambda$")
+        plt.ylabel(r"$\Delta\lambda$")
         plt.legend()
 
         plt.sca(ax[1])
@@ -93,9 +93,9 @@ def _create_shared_wavelength_axis(
             label=f"(shared)/{supersampling}",
             marker=".",
         )
-        plt.title("R = $\lambda/\Delta\lambda$")
+        plt.title(r"R = $\lambda/\Delta\lambda$")
         plt.xlabel(f"Wavelength ({w.unit})")
-        plt.ylabel("R = $\lambda/\Delta\lambda$")
+        plt.ylabel(r"R = $\lambda/\Delta\lambda$")
         plt.legend()
     return shared_w
 
@@ -165,13 +165,16 @@ def align_wavelengths(self, minimum_acceptable_ok=1, minimum_points_per_bin=0, *
         # create a shared wavelength array
         shared_wavelengths = self._create_shared_wavelength_axis(**kw)
 
-        # bin the rainbow onto that new grid, starting from 2D wavelengths
-        shifted = self.bin_in_wavelength(
-            wavelength=shared_wavelengths,
-            minimum_acceptable_ok=minimum_acceptable_ok,
-            starting_wavelengths="2D",
-            minimum_points_per_bin=minimum_points_per_bin,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+
+            # bin the rainbow onto that new grid, starting from 2D wavelengths
+            shifted = self.bin_in_wavelength(
+                wavelength=shared_wavelengths,
+                minimum_acceptable_ok=minimum_acceptable_ok,
+                starting_wavelengths="2D",
+                minimum_points_per_bin=minimum_points_per_bin,
+            )
 
     # append the history entry to the new Rainbow
     shifted._record_history_entry(h)

--- a/chromatic/rainbows/actions/align_wavelengths.py
+++ b/chromatic/rainbows/actions/align_wavelengths.py
@@ -153,7 +153,7 @@ def align_wavelengths(self, minimum_acceptable_ok=1, minimum_points_per_bin=0, *
     h = self._create_history_entry("align_wavelengths", locals())
 
     if "wavelength_2d" not in self.fluxlike:
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         No 2D wavelength information was found, so
         it's assumed wavelengths don't need to be aligned.

--- a/chromatic/rainbows/actions/align_wavelengths.py
+++ b/chromatic/rainbows/actions/align_wavelengths.py
@@ -57,7 +57,6 @@ def _create_shared_wavelength_axis(
         plt.ylabel("Wavelength Index")
         plt.title("R = $\lambda/\Delta\lambda$")
         plt.colorbar(orientation="horizontal", pad=0.25)
-        plt.tight_layout()
 
     min_w, max_w = np.nanmin(w).to("micron").value, np.nanmax(w).to("micron").value
     if wscale == "linear":
@@ -78,6 +77,7 @@ def _create_shared_wavelength_axis(
             shared_dw * supersampling,
             color="black",
             label=f"{supersampling}x(shared)",
+            marker=".",
         )
         plt.title("$\Delta\lambda$")
         plt.xlabel(f"Wavelength ({w.unit})")
@@ -91,12 +91,12 @@ def _create_shared_wavelength_axis(
             shared_R / supersampling,
             color="black",
             label=f"(shared)/{supersampling}",
+            marker=".",
         )
         plt.title("R = $\lambda/\Delta\lambda$")
         plt.xlabel(f"Wavelength ({w.unit})")
         plt.ylabel("R = $\lambda/\Delta\lambda$")
         plt.legend()
-        plt.tight_layout()
     return shared_w
 
 

--- a/chromatic/rainbows/actions/binning.py
+++ b/chromatic/rainbows/actions/binning.py
@@ -509,6 +509,33 @@ def bin_in_wavelength(
     ):
         return self
 
+    if (
+        (self._is_probably_normalized() == False)
+        and (self.uncertainty is not None)
+        and np.any(self.uncertainty != 0)
+    ):
+
+        warnings.warn(
+            f"""
+        It looks like you're trying to bin in wavelength for a
+        Rainbow object that might not be normalized. In the
+        current version of `chromatic`, binning before normalizing
+        might give inaccurate results if the typical uncertainty
+        varies strongly with wavelength.
+
+        Please consider normalizing first, for example with
+        `rainbow.normalize().bin(...)`
+        so that all uncertainties will effectively be relative,
+        and the inverse variance weighting used for binning
+        wavelengths together will give more reasonable answers.
+
+        If you really need to bin before normalizing, please submit
+        an Issue at github.com/zkbt/chromatic/, and we'll try to
+        prioritize implementing a statistically sound solution as
+        soon as possible!
+        """
+        )
+
     # set up binning parameters
     binkw = dict(weighting="inversevariance", drop_nans=False)
 

--- a/chromatic/rainbows/actions/binning.py
+++ b/chromatic/rainbows/actions/binning.py
@@ -51,7 +51,7 @@ def _warn_about_weird_binning(N, dimension, fraction_that_can_be_bad=0.0):
         allow many bins to come from the same data point, so you
         should expect weird correlations.
         """
-        warnings.warn(message)
+        cheerfully_suggest(message)
 
 
 def bin(
@@ -325,7 +325,7 @@ def bin_in_time(
 
         '''
         if k == "uncertainty":
-            warnings.warn(
+            cheerfully_suggest(
                 """
             Uncertainties and/or data quality flags might
             not be handled absolutely perfectly yet...
@@ -379,7 +379,7 @@ def bin_in_time(
         which data you think are usable, (c) change the `minimum_acceptable_ok`
         keyword for `.bin` to a smaller value, and/or (d) try larger bins.
         """
-        warnings.warn(message)
+        cheerfully_suggest(message)
         raise RuntimeError("No good data to bin! (see above)")
 
     # make sure dictionaries are on the up and up
@@ -515,7 +515,7 @@ def bin_in_wavelength(
         and np.any(self.uncertainty != 0)
     ):
 
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         It looks like you're trying to bin in wavelength for a
         Rainbow object that might not be normalized. In the
@@ -638,7 +638,7 @@ def bin_in_wavelength(
         which data you think are usable, (c) change the `minimum_acceptable_ok`
         keyword for `.bin` to a smaller value, and/or (d) try larger bins.
         """
-        warnings.warn(message)
+        cheerfully_suggest(message)
         raise RuntimeError("No good data to bin! (see above)")
 
     # make sure dictionaries are on the up and up

--- a/chromatic/rainbows/actions/fold.py
+++ b/chromatic/rainbows/actions/fold.py
@@ -35,7 +35,7 @@ def fold(self, period=None, t0=None, event="Mid-Transit"):
         Folding to a transit period requires both
         `period` and `t0` be specified. Please try again.
         """
-        warnings.warn(message)
+        cheerfully_suggest(message)
         return self
 
     # create a copy of the existing rainbow

--- a/chromatic/rainbows/actions/inject_spectrum.py
+++ b/chromatic/rainbows/actions/inject_spectrum.py
@@ -46,7 +46,7 @@ def inject_spectrum(
 
     # warn if maybe we shouldn't inject anything
     if np.all(self.flux != 1):
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         None of the pre-existing flux values were 1,
         which hints at the possibility that there

--- a/chromatic/rainbows/actions/remove_trends.py
+++ b/chromatic/rainbows/actions/remove_trends.py
@@ -88,7 +88,7 @@ def remove_trends(
         kw_to_use = dict(size=(1, 11))
         kw_to_use.update(**kw)
         if "size" not in kw:
-            warnings.warn(
+            cheerfully_suggest(
                 f"""
             You didn't supply all expected keywords for '{method}'.
             Relying on defaults, the values will be:
@@ -103,7 +103,7 @@ def remove_trends(
         kw_to_use = dict(window_length=11, polyorder=1)
         kw_to_use.update(**kw)
         if ("window_length" not in kw) or ("polyorder" not in kw):
-            warnings.warn(
+            cheerfully_suggest(
                 f"""
             You didn't supply all expected keywords for '{method}'.
             Relying on defaults, the values will be:
@@ -119,7 +119,7 @@ def remove_trends(
         kw_to_use = dict(deg=1)
         kw_to_use.update(**kw)
         if "deg" not in kw:
-            warnings.warn(
+            cheerfully_suggest(
                 f"""
             You didn't supply all expected keywords for '{method}'.
             Relying on defaults, the values will be:

--- a/chromatic/rainbows/converters/for_altair.py
+++ b/chromatic/rainbows/converters/for_altair.py
@@ -45,7 +45,7 @@ def to_nparray(self, t_unit="d", w_unit="micron"):
         # Change time into the units requested by the user
         t_unit = u.Unit(t_unit)
     except:
-        warnings.warn("Unrecognised Time Format! Returning day by default")
+        cheerfully_suggest("Unrecognised Time Format! Returning day by default")
         t_unit = u.Unit("d")
     rtime = np.array(rtime.to(t_unit).value)
 
@@ -53,7 +53,9 @@ def to_nparray(self, t_unit="d", w_unit="micron"):
         # Change wavelength into the units requested by the user
         w_unit = u.Unit(w_unit)
     except:
-        warnings.warn("Unrecognised Wavelength Format! Returning micron by default")
+        cheerfully_suggest(
+            "Unrecognised Wavelength Format! Returning micron by default"
+        )
         w_unit = u.Unit("micron")
     rwavel = np.array(rwavel.to(w_unit).value)
 

--- a/chromatic/rainbows/get/timelike/time.py
+++ b/chromatic/rainbows/get/timelike/time.py
@@ -39,7 +39,7 @@ def get_times_as_astropy(self, time=None, format=None, scale=None, is_barycentri
     # give a format warning
     format = format or self.get("time_format")
     if format is None:
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         `.metadata['time_details']['format']` is not set,
         nor was a `format=` keyword argument provided.
@@ -62,7 +62,7 @@ def get_times_as_astropy(self, time=None, format=None, scale=None, is_barycentri
         for s in now.SCALES:
             dt = ((getattr(now, s).jd - now.tdb.jd) * u.day).to(u.second)
             differences_string += f"{s:>15} - tdb = {dt:10.6f}\n"
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         .metadata['time_details']['scale'] is not set,
         nor was a `scale=` keyword argument provided.
@@ -82,7 +82,7 @@ def get_times_as_astropy(self, time=None, format=None, scale=None, is_barycentri
     # give some barycenter warnings
     is_barycentric = is_barycentric or self.get("time_is_barycentric")
     if is_barycentric == True and "ut" in scale.lower():
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         barycentic={is_barycentric} and scale={scale}
         It's a deeply weird combination to have a barycentric
@@ -92,7 +92,7 @@ def get_times_as_astropy(self, time=None, format=None, scale=None, is_barycentri
         """
         )
     if is_barycentric != True:
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         The returned time is not known to be measured relative
         to the Solar System barycenter. It's probably therefore
@@ -110,7 +110,7 @@ def get_times_as_astropy(self, time=None, format=None, scale=None, is_barycentri
     if (astropy_time.min().decimalyear < 1000) or (
         astropy_time.max().decimalyear > 3000
     ):
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         The times, which span
         jd={astropy_time.min().jd} to jd={astropy_time.max().jd}

--- a/chromatic/rainbows/get/wavelike/measured_scatter.py
+++ b/chromatic/rainbows/get/wavelike/measured_scatter.py
@@ -48,5 +48,5 @@ def get_measured_scatter(
             if method == "standard-deviation":
                 scatters[i] = np.nanstd(y_value)
             elif method == "MAD":
-                scatters[i] = mad_std(y_value, ignore_nans=True)
+                scatters[i] = mad_std(y_value, ignore_nan=True)
         return scatters * y_unit

--- a/chromatic/rainbows/get/wavelike/measured_scatter.py
+++ b/chromatic/rainbows/get/wavelike/measured_scatter.py
@@ -27,7 +27,7 @@ def get_measured_scatter(
     """
 
     if method not in ["standard-deviation", "MAD"]:
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         '{method}' is not an available method.
         Please choose from ['MAD', 'standard-deviation'].

--- a/chromatic/rainbows/get/wavelike/measured_scatter.py
+++ b/chromatic/rainbows/get/wavelike/measured_scatter.py
@@ -48,5 +48,5 @@ def get_measured_scatter(
             if method == "standard-deviation":
                 scatters[i] = np.nanstd(y_value)
             elif method == "MAD":
-                scatters[i] = median_absolute_deviation(y_value, scale="normal")
+                scatters[i] = mad_std(y_value, ignore_nans=True)
         return scatters * y_unit

--- a/chromatic/rainbows/get/wavelike/measured_scatter_in_bins.py
+++ b/chromatic/rainbows/get/wavelike/measured_scatter_in_bins.py
@@ -35,7 +35,7 @@ def get_measured_scatter_in_bins(
     from ...rainbow import Rainbow
 
     if "remove_trends" in self.history():
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         The `remove_trends` function was applied to this `Rainbow`,
         making it very plausible that some long-timescale signals

--- a/chromatic/rainbows/multi.py
+++ b/chromatic/rainbows/multi.py
@@ -45,7 +45,7 @@ class MultiRainbow:
             or by supplying a list of unique names to the `names=`
             keyword argument when starting your comparison.
             """
-            warnings.warn(message)
+            cheerfully_suggest(message)
 
         # make sure the names and rainbows match up
         assert len(self.names) == len(self.rainbows)

--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -733,7 +733,7 @@ class Rainbow:
             )
 
         # warn if the times and wavelengths are the same size
-        if (self.nwave == self.ntime) and (self.ntime is not None):
+        if (self.nwave == self.ntime) and (self.ntime is not None) and (self.ntime > 1):
             warnings.warn(
                 f"""
             The number of wavelengths ({self.nwave}) is the same as the

--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -184,7 +184,7 @@ class Rainbow:
             Wavelength, time, and flux arrays don't match;
             the `._sort()` step is being skipped.
             """
-            warnings.warn(message)
+            cheerfully_suggest(message)
             return
 
         if np.any(np.diff(i_wavelength) < 0):
@@ -194,7 +194,7 @@ class Rainbow:
             If you want to recover the original wavelength order, the original
             wavelength indices are available in `rainbow.original_wave_index`.
             """
-            warnings.warn(message)
+            cheerfully_suggest(message)
 
         if np.any(np.diff(i_time) < 0):
             message = f"""
@@ -203,7 +203,7 @@ class Rainbow:
             If you want to recover the original time order, the original
             time indices are available in `rainbow.original_time_index`.
             """
-            warnings.warn(message)
+            cheerfully_suggest(message)
 
         # attach unsorted indices to this array, if the don't exist
         if "original_wave_index" not in self.wavelike:
@@ -241,12 +241,12 @@ class Rainbow:
 
             where `x` is the Rainbow you just created.
             """
-            warnings.warn(message)
+            cheerfully_suggest(message)
             return
 
         # kludge to replace zero uncertainties
         # if np.all(self.uncertainty == 0):
-        #    warnings.warn("\nUncertainties were all 0, replacing them with 1!")
+        #    cheerfully_suggest("\nUncertainties were all 0, replacing them with 1!")
         #        self.fluxlike["uncertainty"] = np.ones_like(self.flux)
 
     def _initialize_from_dictionaries(
@@ -720,13 +720,13 @@ class Rainbow:
 
         # make sure there are some times + wavelengths defined
         if self.ntime is None:
-            warnings.warn(
+            cheerfully_suggest(
                 f"""
             No times are defined for this Rainbow.
             """
             )
         if self.nwave is None:
-            warnings.warn(
+            cheerfully_suggest(
                 f"""
             No wavelengths are defined for this Rainbow.
             """
@@ -734,7 +734,7 @@ class Rainbow:
 
         # warn if the times and wavelengths are the same size
         if (self.nwave == self.ntime) and (self.ntime is not None) and (self.ntime > 1):
-            warnings.warn(
+            cheerfully_suggest(
                 f"""
             The number of wavelengths ({self.nwave}) is the same as the
             number of times ({self.ntime}). This is fine, we suppose
@@ -766,13 +766,13 @@ class Rainbow:
             The time array has {self.ntime} times.
             """
             if self.shape == np.shape(self.flux)[::-1]:
-                warnings.warn(
+                cheerfully_suggest(
                     f"""{message}
                     Any chance your flux array is transposed?
                     """
                 )
             else:
-                warnings.warn(message)
+                cheerfully_suggest(message)
 
         for n in ["uncertainty", "ok"]:
             x = getattr(self, n)
@@ -783,7 +783,7 @@ class Rainbow:
                     a shape of {x.shape}, which doesn't match the
                     flux array's shape of {np.shape(self.flux)}.
                     """
-                    warnings.warn(message)
+                    cheerfully_suggest(message)
 
         # make sure 2D arrays are uniquely named from 1D
         for k in tuple(self.fluxlike.keys()):

--- a/chromatic/rainbows/readers/atoca.py
+++ b/chromatic/rainbows/readers/atoca.py
@@ -68,7 +68,7 @@ def from_atoca(rainbow, filepath, order=1):
     else:
         # Ensure that the user knows which order they are getting.
         other_order = {1: 2, 2: 1}[order]
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         You are loading NIRISS order {order} from the ATOCA file
         {filepath}
@@ -134,7 +134,7 @@ def from_atoca(rainbow, filepath, order=1):
     # expected amount.
     n_filled_times = rainbow.fluxlike["flux"].shape[1]
     if n_filled_times != nints:
-        warnings.warn(
+        cheerfully_suggest(
             f"""The extract1d header(s) indicate there should be
             {rainbow.ntime} integrations, but only {n_filled_times} columns of
             the flux array were populated. Are you perhaps missing some

--- a/chromatic/rainbows/readers/coulombe.py
+++ b/chromatic/rainbows/readers/coulombe.py
@@ -34,7 +34,7 @@ def from_coulombe(rainbow, filepath, order=1):
 
     # populate a 1D array of times (with astropy units of time)
     fake_times = np.arange(n_integrations_predicted_by_header) * u.minute
-    warnings.warn("The times are totally made up!")
+    cheerfully_suggest("The times are totally made up!")
     rainbow.timelike["time"] = fake_times
 
     # keep track of integrations loaded yet
@@ -101,7 +101,7 @@ def from_coulombe(rainbow, filepath, order=1):
 
     n_filled_times = np.sum(np.any(np.isfinite(rainbow.flux), rainbow.waveaxis))
     if n_filled_times != rainbow.ntime:
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         The x1dints header(s) indicate there should be {rainbow.ntime} integrations,
         but only {n_filled_times} columns of the flux array were populated. Are you
@@ -119,7 +119,7 @@ def from_coulombe(rainbow, filepath, order=1):
     Loading NIRISS order '{order}'. If you want the other order,
     trying `r = Rainbow(..., format='coulombe', order={other_order})`
     """
-    warnings.warn(message)
+    cheerfully_suggest(message)
 
     # try to guess wscale (and then kludge and call it linear)
     # rainbow._guess_wscale()

--- a/chromatic/rainbows/readers/dossantos.py
+++ b/chromatic/rainbows/readers/dossantos.py
@@ -91,7 +91,7 @@ def from_dossantos(rainbow, filepath):
 
     # populate a 1D array of times (with astropy units of time)
     times = np.arange(len(spectra)) * u.minute
-    warnings.warn("The times are totally made up!")
+    cheerfully_suggest("The times are totally made up!")
     rainbow.timelike["time"] = times * 1
 
     # populate a 2D (row = wavelength, col = array of fluxes

--- a/chromatic/rainbows/readers/espinoza.py
+++ b/chromatic/rainbows/readers/espinoza.py
@@ -39,7 +39,7 @@ def from_espinoza(rainbow, filepath):
 
     # populate a 1D array of times (with astropy units of time)
     times = np.arange(spectra.shape[0]) * u.minute
-    warnings.warn("The times are totally made up!")
+    cheerfully_suggest("The times are totally made up!")
     rainbow.timelike["time"] = times * 1
 
     # populate a 2D (row = wavelength, col = array of fluxes

--- a/chromatic/rainbows/readers/eureka_lcdata.py
+++ b/chromatic/rainbows/readers/eureka_lcdata.py
@@ -24,7 +24,7 @@ def from_eureka_LCData(rainbow, filepath):
     try:
         import astraeus.xarrayIO as xrio
     except ModuleNotFoundError:
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         You are trying import `astraeus`, which is needed for
         reading and writing `Eureka!` pipeline files. We're
@@ -92,7 +92,7 @@ def from_eureka_LCData(rainbow, filepath):
     for k in dataset.keys():
         if (shape in test_shapes) or (shape[::-1] in test_shapes):
             if k not in keys_used:
-                warnings.warn(
+                cheerfully_suggest(
                     f"""
                 While reading a Eureka S4 LCData dataset, the key '{k}'
                 has not been stored as `fluxlike`, `wavelike`, or `timelike`,

--- a/chromatic/rainbows/readers/eureka_specdata.py
+++ b/chromatic/rainbows/readers/eureka_specdata.py
@@ -28,7 +28,7 @@ def from_eureka_SpecData(rainbow, filepath, optimal=True):
     try:
         import astraeus.xarrayIO as xrio
     except ModuleNotFoundError:
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         You are trying import `astraeus`, which is needed for
         reading and writing `Eureka!` pipeline files. We're
@@ -100,7 +100,7 @@ def from_eureka_SpecData(rainbow, filepath, optimal=True):
                 elif shape[::-1] in test_shapes:
                     rainbow._put_array_in_right_dictionary(k, values.T)
             except ValueError:
-                warnings.warn(
+                cheerfully_suggest(
                     f"""
                 While reading a Eureka S3 SpecData dataset, the key '{k}'
                 has not been stored as `fluxlike`, `wavelike`, or `timelike`,

--- a/chromatic/rainbows/readers/nres.py
+++ b/chromatic/rainbows/readers/nres.py
@@ -91,7 +91,7 @@ def from_nres(rainbow, filepath, order=52):
 
     # add some warnings if there's any funny business
     if len(filenames) == 0:
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         There are no files of that name in this folder!
         """

--- a/chromatic/rainbows/readers/radica.py
+++ b/chromatic/rainbows/readers/radica.py
@@ -21,7 +21,7 @@ def from_radica(self, filepath, order=1):
     hdu = fits.open(filepath)
 
     n_orders = 2
-    warnings.warn(
+    cheerfully_suggest(
         f"""
     Loading NIRISS spectroscopic `order={order}``. Two orders are available,
     and you can set which (1,2) you want to read with the `order=` option.

--- a/chromatic/rainbows/readers/template.py
+++ b/chromatic/rainbows/readers/template.py
@@ -94,7 +94,7 @@ def from_abcdefgh(self, filepath):
 
     # add some warnings if there's any funny business
     if something_goes_wonky():
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         Here's a potential problem that the user should know about.
         """

--- a/chromatic/rainbows/readers/x1dints.py
+++ b/chromatic/rainbows/readers/x1dints.py
@@ -36,7 +36,7 @@ def get_times_from_x1dints_files(filenames):
         return timelike
 
     except KeyError:
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         No `int_times` extension was found in the first file
         {filenames[0]})
@@ -65,7 +65,7 @@ def get_times_from_x1dints_files(filenames):
             last_mjd_barycentric_integration_midpoint,
             n_integrations_total,
         )
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         Times were set by linearly interpolating between the exposure
         start and end points. It's very possible these times are off
@@ -95,7 +95,7 @@ def get_wavelengths_from_x1dints_files(
         unit_string = hdu[e].columns["wavelength"].unit
         if unit_string is None:
             unit_string = "micron"
-            warnings.warn("No wavelength unit was found; assuming 'micron'.")
+            cheerfully_suggest("No wavelength unit was found; assuming 'micron'.")
         wavelength_unit = u.Unit(unit_string)
         return {"wavelength": hdu[e].data["wavelength"] * wavelength_unit * 1}
 
@@ -137,7 +137,7 @@ def from_x1dints(rainbow, filepath, order=1, **kw):
 
                 if hdu["PRIMARY"].header["INSTRUME"] == "NIRISS":
                     n_orders = 3
-                    warnings.warn(
+                    cheerfully_suggest(
                         f"""
                     Loading NIRISS spectroscopic `order={order}``. Three orders are available,
                     and you can set which (1,2,3) you want to read with the `order=` option.
@@ -218,7 +218,7 @@ def from_x1dints(rainbow, filepath, order=1, **kw):
 
     n_filled_times = np.sum(np.any(np.isfinite(rainbow.flux), rainbow.waveaxis))
     if n_filled_times != rainbow.ntime:
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         The x1dints header(s) indicate there should be {rainbow.ntime} integrations,
         but only {n_filled_times} columns of the flux array were populated. Are you
@@ -246,4 +246,4 @@ def from_x1dints(rainbow, filepath, order=1, **kw):
 
         where `x` is the Rainbow you just created.
         """
-        warnings.warn(message)
+        cheerfully_suggest(message)

--- a/chromatic/rainbows/readers/x1dints_kludge.py
+++ b/chromatic/rainbows/readers/x1dints_kludge.py
@@ -37,7 +37,7 @@ def setup_integration_times(filenames):
     # if times are not in header, make up some imaginary ones!
     except:
         # alert the user to what we're doing
-        warnings.warn("No times found! Making up imaginary ones!")
+        cheerfully_suggest("No times found! Making up imaginary ones!")
         last_hdu = fits.open(filenames[-1])
 
         # figure out the total number of integrations (DOES THIS NEED THE -1?)
@@ -49,7 +49,9 @@ def setup_integration_times(filenames):
 
         # get the time per integration (DOES THIS INCLUDE OVERHEADS?)
         time_per_integration = last_hdu["PRIMARY"].header["EFFINTTM"] * u.s
-        warnings.warn(f"The imaginary times assume {time_per_integration}/integration.")
+        cheerfully_suggest(
+            f"The imaginary times assume {time_per_integration}/integration."
+        )
 
         # create a fake array of times
         fake_times = np.arange(N_integrations) * time_per_integration
@@ -168,7 +170,7 @@ def from_x1dints_kludge(rainbow, filepath, **kw):
         #  FIXME - it looks like different instruments may have different INTENDs?
     n_filled_times = np.sum(np.any(np.isfinite(rainbow.flux), rainbow.waveaxis))
     if n_filled_times != rainbow.ntime:
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         The x1dints header(s) indicate there should be {rainbow.ntime} integrations,
         but only {n_filled_times} columns of the flux array were populated. Are you
@@ -196,7 +198,7 @@ def from_x1dints_kludge(rainbow, filepath, **kw):
 
         where `x` is the Rainbow you just created.
         """
-        warnings.warn(message)
+        cheerfully_suggest(message)
 
     # try to guess wscale (and then kludge and call it linear)
     # rainbow._guess_wscale()

--- a/chromatic/rainbows/simulated.py
+++ b/chromatic/rainbows/simulated.py
@@ -120,7 +120,7 @@ class SimulatedRainbow(RainbowWithModel):
             You're getting away with it this time,
             but it won't work for much longer!
             """
-            warnings.warn(message)
+            cheerfully_suggest(message)
             new = self.inject_noise()
             for k in ["flux", "uncertainty", "model"]:
                 self.fluxlike[k] = new.fluxlike[k]

--- a/chromatic/rainbows/visualizations/animate.py
+++ b/chromatic/rainbows/visualizations/animate.py
@@ -112,7 +112,7 @@ def _setup_animate_lightcurves(
         https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.text.html
     """
     if (quantity == "flux") and (self._is_probably_normalized() == False):
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         It's not 100% obvious that {self} has been normalized.
         If you're expecting your animation to wobble near 1,
@@ -320,7 +320,7 @@ def _setup_animate_spectra(
     """
 
     if (quantity == "flux") and (self._is_probably_normalized() == False):
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         It's not 100% obvious that {self} has been normalized.
         If you're expecting your animation to wobble near 1,

--- a/chromatic/rainbows/visualizations/colors.py
+++ b/chromatic/rainbows/visualizations/colors.py
@@ -70,7 +70,7 @@ def _make_sure_cmap_is_defined(self, cmap=None, vmin=None, vmax=None):
                 and (vmin != self.get("vmin"))
                 and (vmax != self.get("vmax"))
             ):
-                warnings.warn(
+                cheerfully_suggest(
                     """
                 It looks like you're trying to set up a new custom
                 cmap and/or wavelength normalization scheme. You

--- a/chromatic/rainbows/visualizations/imshow.py
+++ b/chromatic/rainbows/visualizations/imshow.py
@@ -96,7 +96,7 @@ def imshow(
         `rainbow.bin(R=...)` (for logarithmic wavelengths) or
         `rainbow.bin(dw=...)` (for linear wavelengths)
         """
-        warnings.warn(message)
+        cheerfully_suggest(message)
         wlower, wupper = -0.5, self.nwave - 0.5
         wlabel = "Wavelength Index"
 
@@ -129,7 +129,7 @@ def imshow(
         be to bin your times to a more uniform grid with
         `rainbow.bin(dt=...)` (for linear times).
         """
-        warnings.warn(message)
+        cheerfully_suggest(message)
         tlower, tupper = -0.5, self.ntime - 0.5
         tlabel = "Time Index"
 
@@ -157,7 +157,7 @@ def imshow(
         z = get_2D(quantity).T
         ok = get_2D("ok").T
     else:
-        warnings.warn(
+        cheerfully_suggest(
             "Please specify either `xaxis='time'` or `xaxis='wavelength'` for `.plot()`"
         )
 

--- a/chromatic/rainbows/visualizations/interactive.py
+++ b/chromatic/rainbows/visualizations/interactive.py
@@ -7,7 +7,7 @@ try:
     alt.data_transformers.disable_max_rows()
 except Exception as e:
     print(e)
-    warnings.warn(
+    cheerfully_suggest(
         "Issue importing Altair, cannot make interactive plot :(! \n \
                   You can install Altair using: pip install altair"
     )
@@ -74,7 +74,7 @@ def imshow_interact(
         z = "Flux Uncertainty"
     else:
         # if the quantity is not one of the predefined values:
-        warnings.warn("Unrecognised Quantity!")
+        cheerfully_suggest("Unrecognised Quantity!")
         return
 
     # convert rainbow object to pandas dataframe
@@ -84,7 +84,7 @@ def imshow_interact(
     # encourage the user to bin the Rainbow before calling this function in future/
     N_warning = 100000
     if len(source) > N_warning:
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         The dataset {self} has {N_warning} data points/
         The interactive plot may lag. Try binning first!
@@ -92,7 +92,7 @@ def imshow_interact(
         )
 
     if (self._is_probably_normalized() == False) and "model" not in self.fluxlike:
-        warnings.warn(
+        cheerfully_suggest(
             """
         It looks like you might be trying to use `imshow_interact` with an
         unnormalized Rainbow object. You might consider normalizing first

--- a/chromatic/rainbows/visualizations/models/imshow_with_models.py
+++ b/chromatic/rainbows/visualizations/models/imshow_with_models.py
@@ -71,7 +71,7 @@ def imshow_with_models(
     models_that_exist = []
     for m in models:
         if self.get(m) is None:
-            warnings.warn(f"'{m}' doesn't exist and will be skipped.")
+            cheerfully_suggest(f"'{m}' doesn't exist and will be skipped.")
         else:
             models_that_exist.append(m)
     if len(models_that_exist) == 0:

--- a/chromatic/rainbows/visualizations/models/plot_one_wavelength_with_models.py
+++ b/chromatic/rainbows/visualizations/models/plot_one_wavelength_with_models.py
@@ -137,7 +137,7 @@ def plot_one_wavelength_with_models(
     models_that_exist = []
     for m in models:
         if self.get(m) is None:
-            warnings.warn(f"'{m}' doesn't exist and will be skipped.")
+            cheerfully_suggest(f"'{m}' doesn't exist and will be skipped.")
         else:
             models_that_exist.append(m)
     models = models_that_exist

--- a/chromatic/rainbows/visualizations/pcolormesh.py
+++ b/chromatic/rainbows/visualizations/pcolormesh.py
@@ -98,7 +98,7 @@ def pcolormesh(
         z = get_2D(quantity).T
         ok = get_2D("ok").T
     else:
-        warnings.warn(
+        cheerfully_suggest(
             "Please specify either `xaxis='time'` or `xaxis='wavelength'` for `.plot()`"
         )
 

--- a/chromatic/rainbows/visualizations/plot.py
+++ b/chromatic/rainbows/visualizations/plot.py
@@ -28,4 +28,4 @@ def plot(self, xaxis="time", **kw):
     elif xaxis.lower()[0] == "w":
         return self.plot_spectra(**kw)
     else:
-        warnings.warn("Please specify either 'time' or 'wavelength' for `.plot()`")
+        cheerfully_suggest("Please specify either 'time' or 'wavelength' for `.plot()`")

--- a/chromatic/rainbows/visualizations/plot_lightcurves.py
+++ b/chromatic/rainbows/visualizations/plot_lightcurves.py
@@ -198,7 +198,8 @@ def plot_lightcurves(
         plt.xlabel(f"{self._time_label} ({t_unit.to_string('latex_inline')})")
         plt.ylabel("Relative Flux (+ offsets)")
         if ylim is not None:
-            plt.ylim(*ylim)
+            if ylim[1] != ylim[0]:
+                plt.ylim(*ylim)
         plt.title(self.get("title"))
 
     if filename is not None:

--- a/chromatic/rainbows/visualizations/plot_lightcurves.py
+++ b/chromatic/rainbows/visualizations/plot_lightcurves.py
@@ -86,7 +86,7 @@ def plot_lightcurves(
         but this function doesn't know how to
         use them. Sorry!
         """
-        warnings.warn(message)
+        cheerfully_suggest(message)
 
     # make sure that the wavelength-based colormap is defined
     self._make_sure_cmap_is_defined(cmap=cmap, vmin=vmin, vmax=vmax)
@@ -119,7 +119,7 @@ def plot_lightcurves(
         ylim = 1 - np.array([self.nwave + 1, -1]) * spacing
     else:
         label_y = "np.median(plot_y) - 0.5 * spacing"
-        warnings.warn(
+        cheerfully_suggest(
             """
             It's not clear if/how this object has been normalized.
             Be aware that the baseline flux levels may therefore

--- a/chromatic/rainbows/visualizations/plot_spectra.py
+++ b/chromatic/rainbows/visualizations/plot_spectra.py
@@ -93,7 +93,7 @@ def plot_spectra(
         but this function doesn't know how to
         use them. Sorry!
         """
-        warnings.warn(message)
+        cheerfully_suggest(message)
 
     # make sure that the wavelength-based colormap is defined
     self._make_sure_cmap_is_defined(cmap=cmap, vmin=vmin, vmax=vmax)
@@ -120,7 +120,7 @@ def plot_spectra(
     ax._most_recent_chromatic_plot_spacing = spacing
 
     # TO-DO: check if this Rainbow has been normalized
-    '''warnings.warn(
+    '''cheerfully_suggest(
         """
     It's not clear if/how this object has been normalized.
     Be aware that the baseline flux levels may therefore

--- a/chromatic/rainbows/visualizations/utilities.py
+++ b/chromatic/rainbows/visualizations/utilities.py
@@ -207,7 +207,10 @@ def _get_plot_directory(self):
 
 def _label_plot_file(self, filename):
     directory = self._get_plot_directory()
-    return os.path.join(directory, filename.replace(".", f"-{directory}."))
+    if directory == "":
+        return filename
+    else:
+        return os.path.join(directory, filename.replace(".", f"-{directory}."))
 
 
 def savefig(self, filename="test.png", dpi=300, **kw):

--- a/chromatic/rainbows/visualizations/utilities.py
+++ b/chromatic/rainbows/visualizations/utilities.py
@@ -151,7 +151,7 @@ def _scatter_timelike_or_wavelike(
             xlabel = f'{self._time_label} ({t_unit.to_string("latex_inline")})'
             c = wavelength_for_color
         else:
-            warnings.warn(
+            cheerfully_suggest(
                 f"""
             Your requested xaxis='{xaxis} is not allowed.
             Please choose 'time' or 'wavelength'.

--- a/chromatic/rainbows/withmodel.py
+++ b/chromatic/rainbows/withmodel.py
@@ -53,7 +53,7 @@ class RainbowWithModel(Rainbow):
             `rainbow.model = np.ones(rainbow.shape)`
             ...or similarly with a more interesting array.
             """
-            warnings.warn(message)
+            cheerfully_suggest(message)
 
     from .visualizations import (
         plot_with_model,

--- a/chromatic/rainbows/writers/rainbow_FITS.py
+++ b/chromatic/rainbows/writers/rainbow_FITS.py
@@ -35,7 +35,7 @@ def to_rainbow_FITS(self, filepath, overwrite=True):
         try:
             header[k] = self.metadata[k]
         except ValueError:
-            warnings.warn(f"metadata item '{k}' cannot be saved to FITS header")
+            cheerfully_suggest(f"metadata item '{k}' cannot be saved to FITS header")
 
     primary_hdu = fits.PrimaryHDU(header=header)
 

--- a/chromatic/rainbows/writers/template.py
+++ b/chromatic/rainbows/writers/template.py
@@ -71,7 +71,7 @@ def to_abcdefgh(self, filepath):
 
     # add some warnings if there's any funny business
     if something_goes_wonky():
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         Here's a potential problem that the user should know about.
         """

--- a/chromatic/rainbows/writers/xarray_fitted_light_curves.py
+++ b/chromatic/rainbows/writers/xarray_fitted_light_curves.py
@@ -56,7 +56,7 @@ def to_xarray_fitted_light_curves(self, filepath, overwrite=True):
     # warn about missing metadata
     for k in required_attrs:
         if k not in self.metadata:
-            warnings.warn(
+            cheerfully_suggest(
                 f"""
             The required metadata keyword `{k}` was not found.
             Before saving, please set it with `rainbow.{k} = ?`
@@ -99,7 +99,7 @@ def to_xarray_fitted_light_curves(self, filepath, overwrite=True):
     # warn about missing data_vars
     for k in required_coords:
         if k not in coords_dict:
-            warnings.warn(
+            cheerfully_suggest(
                 f"""
             The required coord keyword `{k}` was not found.
             Before saving, please set it with `rainbow.{k} = ?`
@@ -144,7 +144,7 @@ def to_xarray_fitted_light_curves(self, filepath, overwrite=True):
     # warn about missing data_vars
     for k in required_data_vars:
         if k not in ds:
-            warnings.warn(
+            cheerfully_suggest(
                 f"""
             The required data_var keyword `{k}` was not found.
             Before saving, please set it with `rainbow.{k} = ?`

--- a/chromatic/rainbows/writers/xarray_raw_light_curves.py
+++ b/chromatic/rainbows/writers/xarray_raw_light_curves.py
@@ -44,7 +44,7 @@ def to_xarray_raw_light_curves(self, filepath, overwrite=True):
     # warn about missing metadata
     for k in required_attrs:
         if k not in self.metadata:
-            warnings.warn(
+            cheerfully_suggest(
                 f"""
             The required metadata keyword `{k}` was not found.
             Before saving, please set it with `rainbow.{k} = ?`
@@ -88,7 +88,7 @@ def to_xarray_raw_light_curves(self, filepath, overwrite=True):
     # warn about missing data_vars
     for k in required_coords:
         if k not in coords_dict:
-            warnings.warn(
+            cheerfully_suggest(
                 f"""
             The required coord keyword `{k}` was not found.
             Before saving, please set it with `rainbow.{k} = ?`
@@ -123,7 +123,7 @@ def to_xarray_raw_light_curves(self, filepath, overwrite=True):
     # warn about missing data_vars
     for k in required_data_vars:
         if k not in ds:
-            warnings.warn(
+            cheerfully_suggest(
                 f"""
             The required data_var keyword `{k}` was not found.
             Before saving, please set it with `rainbow.{k} = ?`

--- a/chromatic/rainbows/writers/xarray_stellar_spectra.py
+++ b/chromatic/rainbows/writers/xarray_stellar_spectra.py
@@ -36,7 +36,7 @@ def to_xarray_stellar_spectra(self, filepath, overwrite=True):
     # warn about missing metadata
     for k in required_attrs:
         if k not in self.metadata:
-            warnings.warn(
+            cheerfully_suggest(
                 f"""
             The required metadata keyword `{k}` was not found.
             Before saving, please set it with `rainbow.{k} = ?`
@@ -77,7 +77,7 @@ def to_xarray_stellar_spectra(self, filepath, overwrite=True):
     # warn about missing data_vars
     for k in required_coords:
         if k not in coords_dict:
-            warnings.warn(
+            cheerfully_suggest(
                 f"""
             The required coord keyword `{k}` was not found.
             Before saving, please set it with `rainbow.{k} = ?`
@@ -112,7 +112,7 @@ def to_xarray_stellar_spectra(self, filepath, overwrite=True):
     # warn about missing data_vars
     for k in required_data_vars:
         if k not in ds:
-            warnings.warn(
+            cheerfully_suggest(
                 f"""
             The required data_var keyword `{k}` was not found.
             Before saving, please set it with `rainbow.{k} = ?`

--- a/chromatic/resampling.py
+++ b/chromatic/resampling.py
@@ -475,7 +475,7 @@ def bintogrid(
     # warn if multiple inputs are provided
     number_of_grid_options = np.sum([z is not None for z in [newx_edges, newx, dx, nx]])
     if number_of_grid_options > 1:
-        warnings.warn(
+        cheerfully_suggest(
             """More than one output grid sent to `bintogrid`.
                          The one being used is the first to appear in
                          [`newx_edges`, `newx`, `dx`, `nx`]

--- a/chromatic/spectra/phoenix.py
+++ b/chromatic/spectra/phoenix.py
@@ -841,13 +841,15 @@ class PHOENIXLibrary:
                         weights[i] = wt * wg * wz
                         key = (t, g, z)
                         try:
-                            this_log_spectrum = np.log(
-                                self._get_spectrum_from_grid(
-                                    key,
-                                    wavelength=wavelength,
-                                    wavelength_edges=wavelength_edges,
+                            with warnings.catch_warnings():
+                                warnings.simplefilter("ignore")
+                                this_log_spectrum = np.log(
+                                    self._get_spectrum_from_grid(
+                                        key,
+                                        wavelength=wavelength,
+                                        wavelength_edges=wavelength_edges,
+                                    )
                                 )
-                            )
                         except KeyError:
                             raise ValueError(
                                 f"""
@@ -986,7 +988,7 @@ class PHOENIXLibrary:
             if k != "R":
                 plt.loglog(timings["R"], timings[k], marker="o", label=k, alpha=0.3)
         plt.legend(bbox_to_anchor=(1, 1), frameon=False)
-        plt.xlabel("R = $\lambda/\Delta\lambda$")
+        plt.xlabel(r"R = $\lambda/\Delta\lambda$")
         plt.ylabel("Time Required")
         return t
 

--- a/chromatic/spectra/phoenix.py
+++ b/chromatic/spectra/phoenix.py
@@ -155,7 +155,7 @@ class PHOENIXLibrary:
         self._raw_wavelengths_url = "/".join(
             [self._raw_base_url, self._raw_wavelengths_filename]
         )
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         Downloading (or finding locally) the shared wavelength grid from
         {self._raw_wavelengths_url}
@@ -174,7 +174,7 @@ class PHOENIXLibrary:
         ] = download_file_with_warning(
             self._raw_directory_url, pkgname=self._cache_label, cache=cache
         )
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         Downloading (or finding locally) the index of files from
         {self._raw_directory_url}
@@ -198,7 +198,7 @@ class PHOENIXLibrary:
             for f in self._raw_spectrum_filenames
         ]
         N = len(self._raw_spectrum_urls)
-        warnings.warn(
+        cheerfully_suggest(
             f"""
         Downloading (or finding locally) {N} very large files from
         {self._raw_directory_url}
@@ -502,7 +502,7 @@ class PHOENIXLibrary:
         if np.any(ok):
             i = np.flatnonzero(ok)[0]
         else:
-            warnings.warn(
+            cheerfully_suggest(
                 f"""
             Your request resolution of R={R} is higher than the maximum.
             It will be rounded down to R={np.max(self._available_resolutions)}.
@@ -513,7 +513,7 @@ class PHOENIXLibrary:
         if i is not None:
             smallest_sufficient_R = self._available_resolutions[i]
         else:
-            warnings.warn(
+            cheerfully_suggest(
                 f"""
             Your requested resolution of R={R}
             is higher than the largest possible value

--- a/chromatic/tests/__init__.py
+++ b/chromatic/tests/__init__.py
@@ -18,3 +18,4 @@ from .test_history import *
 from .test_spectra import *
 from .test_remove_trends import *
 from .test_time import *
+from .test_fold import *

--- a/chromatic/tests/test_basics.py
+++ b/chromatic/tests/test_basics.py
@@ -4,7 +4,7 @@ from .setup_tests import *
 
 def test_rainbow_basics():
 
-    nw, nt = 24, 48
+    nw, nt = 24, 72
     r = Rainbow(
         wavelength=np.linspace(1, 2, nw) * u.micron,
         time=np.linspace(-1, 1, nt) * u.hour,
@@ -109,25 +109,22 @@ def test_shape_warnings():
 def test_sort():
     w = np.linspace(2, 1) * u.micron
     t = np.linspace(1, -1) * u.day
-    r = SimulatedRainbow(wavelength=w, time=t).inject_noise()
-    print(r.wavelength)
-    print(r.time)
-    r._validate_core_dictionaries()
-    print(r.wavelength)
-    print(r.time)
-    assert np.all(r.wavelength == w[::-1])
-    assert np.all(r.time == t[::-1])
 
-    # test the warnings
     with pytest.warns(match="input times were not monotonically increasing"):
         r = SimulatedRainbow(time=t).inject_noise()
         r._validate_core_dictionaries()
-        r.original_time_index
+        print(r.wavelength)
+        print(r.time)
+        print(r.original_time_index)
+        assert np.all(r.time == t[::-1])
 
     with pytest.warns(match="input wavelengths were not monotonically increasing"):
         r = SimulatedRainbow(wavelength=w).inject_noise()
         r._validate_core_dictionaries()
-        r.original_wave_index
+        print(r.wavelength)
+        print(r.time)
+        print(r.original_wave_index)
+        assert np.all(r.wavelength == w[::-1])
 
 
 def test_help():

--- a/chromatic/tests/test_binning.py
+++ b/chromatic/tests/test_binning.py
@@ -67,7 +67,6 @@ def test_bin():
     plt.title("Unbinned")
     b.imshow(ax=ax[1], **imshowkw)
     plt.title("Binned")
-    plt.tight_layout()
     plt.savefig(os.path.join(test_directory, "imshow-bin-demonstration.pdf"))
     plt.close("all")
 
@@ -277,3 +276,8 @@ def test_uncertainty_weighting_during_binning():
         os.path.join(test_directory, "uncertainty-weighting-during-binning.png"),
         facecolor="white",
     )
+
+
+def test_warning_about_binning_before_normalizing():
+    with pytest.warns(match="Please consider normalizing"):
+        SimulatedRainbow().inject_spectrum().inject_noise().bin(R=10)

--- a/chromatic/tests/test_binning.py
+++ b/chromatic/tests/test_binning.py
@@ -15,7 +15,8 @@ def test_bin_in_time():
     imshowkw = dict(vmin=0.98, vmax=1.02)
     s.imshow(ax=ax[0], **imshowkw)
     b.imshow(ax=ax[1], **imshowkw)
-    plt.savefig(os.path.join(test_directory, "imshow-bin-time-demonstration.pdf"))
+    plt.savefig(os.path.join(test_directory, "demonstration-of-binning-in-time.pdf"))
+    plt.close("all")
 
 
 def test_bin_in_wavelength():
@@ -35,7 +36,9 @@ def test_bin_in_wavelength():
     imshowkw = dict(vmin=0.98, vmax=1.02)
     s.imshow(ax=ax[0], **imshowkw)
     b.imshow(ax=ax[1], **imshowkw)
-    plt.savefig(os.path.join(test_directory, "imshow-bin-wavelength-demonstration.pdf"))
+    plt.savefig(
+        os.path.join(test_directory, "demonstration-of-binning-in-wavelength.pdf")
+    )
     plt.close("all")
 
 
@@ -61,13 +64,17 @@ def test_bin():
         == s
     )
 
-    fi, ax = plt.subplots(2, 1, sharex=True)
+    fi, ax = plt.subplots(2, 1, sharex=True, constrained_layout=True)
     imshowkw = dict(vmin=0.98, vmax=1.02)
     s.imshow(ax=ax[0], **imshowkw)
     plt.title("Unbinned")
     b.imshow(ax=ax[1], **imshowkw)
     plt.title("Binned")
-    plt.savefig(os.path.join(test_directory, "imshow-bin-demonstration.pdf"))
+    plt.savefig(
+        os.path.join(
+            test_directory, "demonstration-of-binning-in-both-wavelength-and-time.pdf"
+        )
+    )
     plt.close("all")
 
 
@@ -165,6 +172,9 @@ def test_bin_bad_data(visualize=False):
         b.imshow(ax=ax[1, 1], vmin=0.97, vmax=1.03)
 
     assert np.any(np.isfinite(b.flux))
+    plt.savefig(
+        os.path.join(test_directory, "demonstration-of-binning-with-bad-data.pdf")
+    )
     plt.close("all")
     return s
 
@@ -174,44 +184,49 @@ def test_bin_both():
     binwave = 0.1
     w = np.logspace(0, 1) * u.micron
     r = SimulatedRainbow(dt=bintime * u.minute).inject_noise(signal_to_noise=1000)
-    b_withouttransit = r.bin(dw=binwave * u.micron, dt=bintime * u.minute)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        b = r.bin(dw=binwave * u.micron, dt=bintime * u.minute)
 
 
 def test_binning_to_one():
     """
     Are things OK even if we bin down to one wavelength or time?
     """
-    for N in np.random.randint(2, 100, 3):
-        for M in np.random.randint(2, 100, 3):
-            w = np.linspace(1, 2, N) * u.micron
-            t = np.linspace(-1, 1, M) * u.hour
-            s = SimulatedRainbow(wavelength=w, time=t).inject_noise()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
 
-            bw = s.bin(nwavelengths=s.nwave)
-            print(bw.uncertainty[0, 0], s.uncertainty[0, 0] / np.sqrt(s.nwave))
-            predicted = 1 / np.sqrt(np.sum(1 / s.uncertainty**2, axis=s.waveaxis))
-            assert np.all(
-                np.isclose(
-                    predicted,
-                    np.mean(bw.uncertainty, axis=s.waveaxis),
-                    rtol=1e-10,
-                    atol=1e-13,
-                )
-            )
-            assert bw.nwave == 1
+        for N in np.random.randint(2, 100, 3):
+            for M in np.random.randint(2, 100, 3):
+                w = np.linspace(1, 2, N) * u.micron
+                t = np.linspace(-1, 1, M) * u.hour
+                s = SimulatedRainbow(wavelength=w, time=t).inject_noise()
 
-            bt = s.bin(ntimes=s.ntime)
-            print(bt.uncertainty[0, 0], s.uncertainty[0, 0] / np.sqrt(s.ntime))
-            predicted = 1 / np.sqrt(np.sum(1 / s.uncertainty**2, axis=s.timeaxis))
-            assert np.all(
-                np.isclose(
-                    predicted,
-                    np.mean(bt.uncertainty, axis=s.timeaxis),
-                    rtol=1e-10,
-                    atol=1e-13,
+                bw = s.bin(nwavelengths=s.nwave)
+                print(bw.uncertainty[0, 0], s.uncertainty[0, 0] / np.sqrt(s.nwave))
+                predicted = 1 / np.sqrt(np.sum(1 / s.uncertainty**2, axis=s.waveaxis))
+                assert np.all(
+                    np.isclose(
+                        predicted,
+                        np.mean(bw.uncertainty, axis=s.waveaxis),
+                        rtol=1e-10,
+                        atol=1e-13,
+                    )
                 )
-            )
-            assert bt.ntime == 1
+                assert bw.nwave == 1
+
+                bt = s.bin(ntimes=s.ntime)
+                print(bt.uncertainty[0, 0], s.uncertainty[0, 0] / np.sqrt(s.ntime))
+                predicted = 1 / np.sqrt(np.sum(1 / s.uncertainty**2, axis=s.timeaxis))
+                assert np.all(
+                    np.isclose(
+                        predicted,
+                        np.mean(bt.uncertainty, axis=s.timeaxis),
+                        rtol=1e-10,
+                        atol=1e-13,
+                    )
+                )
+                assert bt.ntime == 1
 
 
 def test_bin_with_minimum_points_per_bin():
@@ -235,16 +250,22 @@ def test_bin_with_minimum_points_per_bin():
             )
             b.imshow(ax=ax[i, j], colorbar=False)
             plt.ylim(5, 0.5)
-            plt.title(f"minimum_points_per_bin={t}, trim={trim}")
+            plt.title(f"minimum_points_per_bin={t},\ntrim={trim}")
 
-    plt.savefig(os.path.join(test_directory, "binning-with-minimum_points_per_bin.png"))
+    plt.savefig(
+        os.path.join(
+            test_directory,
+            "demonstration-of-binning-with-different-minimum-required-points-per-bin.pdf",
+        )
+    )
+    plt.close("all")
 
 
 def test_integrated_wrappers():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
 
-        s = SimulatedRainbow().inject_transit().inject_noise()
+        s = SimulatedRainbow(dt=5 * u.minute, R=20).inject_transit().inject_noise()
         s.fluxlike["flux"] += 0.003 * s.wavelength.value[:, np.newaxis]
 
         fi, ax = plt.subplots(1, 3, figsize=(10, 3), constrained_layout=True)
@@ -273,7 +294,9 @@ def test_uncertainty_weighting_during_binning():
         lc = t.get_average_lightcurve_as_rainbow()
         lc.plot_with_model(ax=ax[3, col])
     plt.savefig(
-        os.path.join(test_directory, "uncertainty-weighting-during-binning.png"),
+        os.path.join(
+            test_directory, "demonstration-of-binning-uncertainty-weighting.pdf"
+        ),
         facecolor="white",
     )
 

--- a/chromatic/tests/test_fold.py
+++ b/chromatic/tests/test_fold.py
@@ -2,14 +2,26 @@ from ..rainbows import *
 from .setup_tests import *
 
 
-def test_fold():
-    original_time = np.linspace(-0.1, 0.1) * u.day
+def test_fold(N=5):
 
     for i in range(5):
-        period = np.random.uniform(1, 20) * u.day
+        original_time = (
+            np.linspace(np.random.uniform(-1, -0.2), np.random.uniform(0.2, 1), 500)
+            * u.day
+        )
+        period = np.random.uniform(1, 10) * u.day
         t0 = np.random.uniform(-10, 10) * u.day
         N = np.random.randint(-10, 10)
-        s = SimulatedRainbow(time=original_time + t0 + period * N).inject_noise()
-        assert np.all(
-            np.isclose(s.fold(period=period, t0=t0).time, original_time, atol=1e-12)
+        s = (
+            SimulatedRainbow(time=original_time + t0 + period * N, R=5)
+            .inject_transit(per=period.to_value("day"), t0=t0.to_value("day"))
+            .inject_noise(signal_to_noise=1000)
         )
+        f = s.fold(period=period, t0=t0)
+        assert np.all(np.isclose(f.time, original_time, atol=1e-12))
+    fi, ax = plt.subplots(1, 2, figsize=(8, 3), constrained_layout=True)
+    s.imshow(ax=ax[0])
+    f.imshow(ax=ax[1])
+    plt.savefig(
+        os.path.join(test_directory, "demonstration-of-folding-to-period-and-t0.pdf")
+    )

--- a/chromatic/tests/test_fold.py
+++ b/chromatic/tests/test_fold.py
@@ -6,7 +6,7 @@ def test_fold(N=5):
 
     for i in range(5):
         original_time = (
-            np.linspace(np.random.uniform(-1, -0.2), np.random.uniform(0.2, 1), 500)
+            np.linspace(np.random.uniform(-0.5, -0.2), np.random.uniform(0.2, 0.5), 500)
             * u.day
         )
         period = np.random.uniform(1, 10) * u.day

--- a/chromatic/tests/test_inject_systematics.py
+++ b/chromatic/tests/test_inject_systematics.py
@@ -1,9 +1,0 @@
-from ..rainbows import *
-from .setup_tests import *
-
-
-def test_inject_systematics():
-    SimulatedRainbow().inject_transit().inject_noise().inject_systematics().bin(
-        R=10, dt=10 * u.minute
-    ).imshow_quantities()
-    plt.savefig(os.path.join(test_directory, "inject_systematics_demo.pdf"))

--- a/chromatic/tests/test_io.py
+++ b/chromatic/tests/test_io.py
@@ -13,7 +13,9 @@ def test_rainbow_npy():
 def test_rainbow_FITS():
     filename = os.path.join(test_directory, "test.rainbow.fits")
     a = SimulatedRainbow().inject_noise()
-    a.save(filename, overwrite=True)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        a.save(filename, overwrite=True)
     b = read_rainbow(filename)
     assert a == b
 
@@ -36,7 +38,9 @@ def test_xarray():
         filename = os.path.join(test_directory, f)
         print(filename)
         a = SimulatedRainbow().inject_transit().inject_systematics().inject_noise()
-        a.save(filename)
+
+        with pytest.warns(match="required metadata keyword"):
+            a.save(filename)
         b = read_rainbow(filename)
         assert a == b
 

--- a/chromatic/tests/test_ok.py
+++ b/chromatic/tests/test_ok.py
@@ -23,7 +23,7 @@ def test_bin_with_not_ok_data():
         a.ok = np.random.uniform(size=a.shape) < ok_fraction
 
         if ok_fraction == 0:
-            with pytest.raises(RuntimeError):
+            with pytest.raises((RuntimeError, IndexError)):
                 should_fail = a.bin(
                     dw=0.7 * u.micron, dt=20 * u.minute, minimum_acceptable_ok=1
                 )

--- a/chromatic/tests/test_operations.py
+++ b/chromatic/tests/test_operations.py
@@ -46,19 +46,20 @@ def test_rainbow_operations():
     assert (a / 1).fluxlike["flux"][0][0] == 1
 
     # make sure we raise an error if it's not obvious whether we're doing wavelength or time
-    c = Rainbow(
-        wavelength=np.linspace(0.5, 5, nw) * u.micron,
-        time=np.linspace(-1, 1, nw) * u.hour,
-        flux=np.ones((nw, nw)),
-    )
-    with pytest.raises(Exception):
-        c * wl_like
-    with pytest.raises(Exception):
-        c / wl_like
-    with pytest.raises(Exception):
-        c + wl_like
-    with pytest.raises(Exception):
-        c - wl_like
+    with pytest.warns(match="reconsider letting them have the same size"):
+        c = Rainbow(
+            wavelength=np.linspace(0.5, 5, nw) * u.micron,
+            time=np.linspace(-1, 1, nw) * u.hour,
+            flux=np.ones((nw, nw)),
+        )
+        with pytest.raises(Exception):
+            c * wl_like
+        with pytest.raises(Exception):
+            c / wl_like
+        with pytest.raises(Exception):
+            c + wl_like
+        with pytest.raises(Exception):
+            c - wl_like
 
 
 def test_operations_with_uncertainty():

--- a/chromatic/tests/test_remove_trends.py
+++ b/chromatic/tests/test_remove_trends.py
@@ -12,7 +12,7 @@ def test_remove_trends():
     fi, ax = plt.subplots(
         2,
         6,
-        figsize=(12, 6),
+        figsize=(12, 5),
         sharey="row",
         sharex=True,
         dpi=300,
@@ -20,18 +20,36 @@ def test_remove_trends():
     )
     imkw = dict(vmin=0.98, vmax=1.02, xaxis="wavelength", colorbar=False)
     s.imshow(ax=ax[0, 0], **imkw)
+    plt.title("raw data")
     s.plot_noise_comparison(ax=ax[1, 0])
     for i, method in enumerate(
         ["median_filter", "savgol_filter", "differences", "polyfit"]
     ):
-        x = s.remove_trends(method=method)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            x = s.remove_trends(method=method)
         x.imshow(ax=ax[0, 1 + i], **imkw)
         ax[0, i + 1].set_title(method)
         x.plot_noise_comparison(ax=ax[1, i + 1])
+
     x = s.remove_trends(method="custom", model=s.planet_model)
     ax[0, -1].set_title("custom")
 
     x.imshow(ax=ax[0, -1], **imkw)
     x.plot_noise_comparison(ax=ax[1, -1])
     plt.ylim(0, 0.02)
-    plt.savefig(os.path.join(test_directory, "test-remove_trends.png"))
+    plt.title("actual systematics")
+    plt.savefig(
+        os.path.join(
+            test_directory,
+            "demonstration-of-removing-trends-with-different-methods.pdf",
+        )
+    )
+
+
+def test_remove_trends_options():
+    s = SimulatedRainbow().inject_noise()
+    for method in ["median_filter", "savgol_filter", "polyfit"]:
+        with pytest.warns(match="didn't supply all expected keywords for"):
+            s.remove_trends(method=method)

--- a/chromatic/tests/test_resampling.py
+++ b/chromatic/tests/test_resampling.py
@@ -21,22 +21,38 @@ def test_resampling():
     x_new = (x_new_edges[1:] + x_new_edges[:-1]) / 2
 
     a = resample_while_conserving_flux(xin=x, yin=y, xout=x_new, visualize=True)
-    plt.savefig(os.path.join(resample_directory, "resampling-demonstration-a.pdf"))
+    plt.savefig(
+        os.path.join(
+            resample_directory, "demonstration-of-resampling-centers-in-centers-out.pdf"
+        )
+    )
 
     b = resample_while_conserving_flux(
         yin=y, xout=x_new, xin_edges=x_edges, visualize=True
     )
-    plt.savefig(os.path.join(resample_directory, "resampling-demonstration-b.pdf"))
+    plt.savefig(
+        os.path.join(
+            resample_directory, "demonstration-of-resampling-edges-in-centers-out.pdf"
+        )
+    )
 
     c = resample_while_conserving_flux(
         yin=y, xin_edges=x_edges, xout_edges=x_new_edges, visualize=True
     )
-    plt.savefig(os.path.join(resample_directory, "resampling-demonstration-c.pdf"))
+    plt.savefig(
+        os.path.join(
+            resample_directory, "demonstration-of-resampling-edges-in-edges-out.pdf"
+        )
+    )
 
     d = resample_while_conserving_flux(
         yin=y, xin=x, xout_edges=x_new_edges, visualize=True
     )
-    plt.savefig(os.path.join(resample_directory, "resampling-demonstration-d.pdf"))
+    plt.savefig(
+        os.path.join(
+            resample_directory, "demonstration-of-resampling-centers-in-edges-out.pdf"
+        )
+    )
 
     for x in [b, c, d]:
         assert np.isclose(np.sum(a["y"]), np.sum(x["y"]))
@@ -54,8 +70,9 @@ def test_bintogrid(N_original=23):
 
     def save_binning_example_figure():
         f = plt.gca().get_title()
-        f = f.replace(" ", "") + ".pdf"
+        f = "demonstration-of-" + f.replace(" ", "") + ".pdf"
         f = f.replace("$\sigma$", "uncertainty")
+        f = f.replace(",", "-")
         plt.savefig(os.path.join(bin_directory, f))
 
     for input_grid in ["uniform", "irregular"]:
@@ -98,7 +115,7 @@ def test_bintogrid(N_original=23):
                 save_binning_example_figure()
                 assert np.all(np.isclose(a["y"], c["y"]))
 
-            label = f"{input_grid} input grid, {uncertainties} $\sigma$"
+            label = f"{input_grid} input grid, {uncertainties} " + r"$\sigma$"
 
             # does binning to self give self?
             d = bintogrid(x, y, unc=u, newx=x, visualize=True)

--- a/chromatic/tests/test_shift.py
+++ b/chromatic/tests/test_shift.py
@@ -23,6 +23,12 @@ def test_shift():
         unshifted.imshow(ax=ax[0])
         shifted.imshow(ax=ax[1])
         shifted_and_then_shifted_back.imshow(ax=ax[2])
+        plt.savefig(
+            os.path.join(
+                test_directory,
+                "demonstration-of-shifting-wavelengths.pdf",
+            )
+        )
 
         assert np.all(
             np.isclose(unshifted.wavelength, shifted_and_then_shifted_back.wavelength)

--- a/chromatic/tests/test_simulations.py
+++ b/chromatic/tests/test_simulations.py
@@ -24,14 +24,19 @@ def test_photon_noise(N=10000):
     # imshow the two ways
     fi, ax = plt.subplots(1, 2, figsize=(8, 3), dpi=300, constrained_layout=True)
     gaussian.imshow(ax=ax[0])
-    ax[0].set_title(f"Gaussian ($\sigma=${1/np.sqrt(N):.3f}=" + "$1/\sqrt{N}$)")
+    ax[0].set_title(r"Gaussian ($\sigma=$" + f"{1/np.sqrt(N):.3f}=" + r"$1/\sqrt{N}$)")
     poisson.imshow(ax=ax[1])
     ax[1].set_title(f"Poisson (N={N})")
 
     # make sure the standard deviation is about right
     # sigma = np.std(poisson.residuals / poisson.model)
     # assert np.isclose(sigma, 1 / np.sqrt(N), rtol=0.1)
-    plt.savefig(os.path.join(test_directory, "poisson+gaussian-noise.png"))
+    plt.savefig(
+        os.path.join(
+            test_directory,
+            "demonstration-of-injecting-noise-as-poisson-or-gaussian.pdf",
+        )
+    )
 
 
 def test_star_flux():
@@ -62,5 +67,14 @@ def test_inject_transit():
             ),
         },
     ).imshow(ax=ax[2], vmin=0.975, vmax=1.005)
-    plt.savefig(os.path.join(test_directory, "transit-injection-demonstration.pdf"))
+    plt.savefig(os.path.join(test_directory, "demonstration-of-injecting-transit.pdf"))
     plt.close("all")
+
+
+def test_inject_systematics():
+    SimulatedRainbow().inject_transit().inject_noise().inject_systematics().bin(
+        R=10, dt=10 * u.minute
+    ).imshow_with_models()
+    plt.savefig(
+        os.path.join(test_directory, "demonstration-of-injecting-fake-systematics.pdf")
+    )

--- a/chromatic/tests/test_spectra.py
+++ b/chromatic/tests/test_spectra.py
@@ -22,7 +22,11 @@ def test_spectral_library_R(cmap=one2another("indigo", "tomato"), N=5):
             plt.text(0.98, 0.92, f"R={R}", transform=a.transAxes, ha="right", va="top")
     fi.supxlabel(f"Wavelength ({w.unit.to_string('latex_inline')})")
     fi.supylabel(f"Surface Flux ({f.unit.to_string('latex_inline')})")
-    plt.savefig(os.path.join(test_directory, "test-spectral-library-constant-R.png"))
+    plt.savefig(
+        os.path.join(
+            test_directory, "demonstration-of-spectral-library-with-constant-R.pdf"
+        )
+    )
 
 
 def test_spectral_library_wavelengths(cmap=one2another("indigo", "tomato"), N=5):
@@ -48,7 +52,10 @@ def test_spectral_library_wavelengths(cmap=one2another("indigo", "tomato"), N=5)
     fi.supxlabel(f"Wavelength ({w.unit.to_string('latex_inline')})")
     fi.supylabel(f"Surface Flux ({f.unit.to_string('latex_inline')})")
     plt.savefig(
-        os.path.join(test_directory, "test-spectral-library-custom_wavelengths.png")
+        os.path.join(
+            test_directory,
+            "demonstration-of-spectral-library-with-custom-wavelengths.pdf",
+        )
     )
 
 
@@ -66,6 +73,7 @@ def test_spectral_library_loads_correct_R():
         plt.plot(wamb, s_amb)
     plt.savefig(
         os.path.join(
-            test_directory, "test-spectral-library-load-correct-resolution.png"
+            test_directory,
+            "demonstration-of-spectral-library-loading-minimum-necessary-resolution.pdf",
         )
     )

--- a/chromatic/tests/test_summaries.py
+++ b/chromatic/tests/test_summaries.py
@@ -7,12 +7,17 @@ def test_lightcurve_and_spectrum_summaries():
     s = SimulatedRainbow().inject_noise().inject_transit()
     ax[0].plot(s.time, s.get_average_lightcurve())
     ax[1].plot(s.wavelength, s.get_average_spectrum())
+    plt.savefig(
+        os.path.join(
+            test_directory, "demonstration-of-average-lightcurve-and-spectrum.pdf"
+        )
+    )
 
 
 def test_measured_scatter_summary():
     # make a fake Rainbow with known noise
     signal_to_noise = 100
-    s = SimulatedRainbow(signal_to_noise=signal_to_noise)
+    s = SimulatedRainbow().inject_noise(signal_to_noise=signal_to_noise)
 
     # mathematically, what do we expect?
     expected_sigma = 1 / signal_to_noise
@@ -66,4 +71,4 @@ def test_measured_scatter_summary():
             < uncertainty_on_expected_sigma * many_sigma
         )
 
-    plt.savefig(os.path.join(test_directory, "measured-scatter-demo.png"))
+    plt.savefig(os.path.join(test_directory, "demonstration-of-measured-scatter.pdf"))

--- a/chromatic/tests/test_time.py
+++ b/chromatic/tests/test_time.py
@@ -3,12 +3,14 @@ from .setup_tests import *
 
 
 def test_astropy_times():
-    s = SimulatedRainbow()
+    s = SimulatedRainbow(time=(Time.now().jd + np.linspace(0, 1)) * u.day)
     format = "jd"
     scale = "tdb"
     original_times = s.time
-    astropy_times = s.get_times_as_astropy(format=format, scale=scale)
-    s.set_times_from_astropy(astropy_times)
+    astropy_times = s.get_times_as_astropy(
+        format=format, scale=scale, is_barycentric=True
+    )
+    s.set_times_from_astropy(astropy_times, is_barycentric=True)
 
     assert np.all(s.time == original_times)
     assert np.all(astropy_times == s.get_times_as_astropy())

--- a/chromatic/tests/test_units.py
+++ b/chromatic/tests/test_units.py
@@ -4,3 +4,6 @@ from .setup_tests import *
 
 def test_custom_units():
     u.Unit("(MJy/sr)^2")
+    u.Unit("(DN/s)^2")
+    u.Unit("microns")
+    u.Unit("electrons")

--- a/chromatic/tests/test_visualizations.py
+++ b/chromatic/tests/test_visualizations.py
@@ -4,8 +4,11 @@ from ..rainbows.visualizations import _add_panel_labels
 
 
 def test_imshow():
+    plt.close("all")
+
     plt.figure()
-    SimulatedRainbow(R=10).imshow()
+    SimulatedRainbow(R=20).imshow()
+    plt.savefig(os.path.join(test_directory, "demonstration-of-imshow.pdf"))
 
     plt.figure()
     SimulatedRainbow(dw=0.2 * u.micron).imshow()
@@ -20,10 +23,12 @@ def test_imshow():
     fi, ax = plt.subplots(2, 1, sharex=True)
     SimulatedRainbow(R=10).inject_noise().imshow(w_unit="nm", ax=ax[0])
     SimulatedRainbow(dw=0.2 * u.micron).inject_noise().imshow(ax=ax[1], w_unit="nm")
-    plt.savefig(os.path.join(test_directory, "demonstration-of-imshow.pdf"))
+    plt.savefig(os.path.join(test_directory, "demonstration-of-imshow-units.pdf"))
 
 
 def test_imshow_quantities():
+    plt.close("all")
+
     s = SimulatedRainbow().inject_transit().inject_noise(signal_to_noise=500)
     for k in "abcde":
         s.fluxlike[k] = np.random.uniform(4, 5, s.shape)
@@ -32,11 +37,15 @@ def test_imshow_quantities():
 
 
 def test_plot():
+    plt.close("all")
+
     SimulatedRainbow(R=10).inject_noise().plot()
     plt.savefig(os.path.join(test_directory, "demonstration-of-plot.pdf"))
 
 
 def test_plot_unnormalized():
+    plt.close("all")
+
     w = np.logspace(0, 1, 5) * u.micron
     plt.figure()
     s = SimulatedRainbow(wavelength=w, star_flux=w.value**2).inject_noise(
@@ -52,6 +61,8 @@ def test_plot_unnormalized():
 
 
 def test_plot_quantities():
+    plt.close("all")
+
     r = SimulatedRainbow(R=10).inject_noise()
     for k in "abcdefg":
         r.timelike[f'timelike quantity "{k}"'] = np.random.normal(0, 1, r.ntime) * u.m
@@ -69,6 +80,8 @@ def test_plot_quantities():
 
 
 def test_animate():
+    plt.close("all")
+
     # test a transit, since along both dimensions
     d = SimulatedRainbow(dw=0.1 * u.micron, dt=5 * u.minute).inject_noise(
         signal_to_noise=1000
@@ -92,6 +105,8 @@ def test_animate():
 
 
 def test_animate_other_quantities():
+    plt.close("all")
+
     k = "some-imaginary-fluxlike-quantity"
     s = (
         SimulatedRainbow(R=5, dt=20 * u.minute)
@@ -116,6 +131,7 @@ def test_animate_other_quantities():
 
 
 def test_cmap():
+    plt.close("all")
 
     r = SimulatedRainbow(R=10).inject_noise()
 
@@ -128,16 +144,22 @@ def test_cmap():
 
 
 def test_imshow_interact():
+    plt.close("all")
+
     plt.figure()
     SimulatedRainbow(R=10).inject_noise().imshow_interact()
 
 
 def test_plot_one_wavelength():
+    plt.close("all")
+
     s = SimulatedRainbow(wavelength=[1] * u.micron).inject_noise()
     s.plot()
 
 
 def test_imshow_one_wavelength():
+    plt.close("all")
+
     with pytest.warns(match="hard to imshow "):
 
         s = SimulatedRainbow(wavelength=[1] * u.micron).inject_noise()
@@ -149,10 +171,17 @@ def test_imshow_one_wavelength():
         ax = b.imshow()
         assert "Wavelength (" in ax.get_ylabel()
         ylim = ax.get_ylim()
-        plt.close("all")
+    plt.savefig(
+        os.path.join(
+            test_directory,
+            f"demonstration-of-imshow-with-just-one-wavelength.pdf",
+        )
+    )
 
 
 def test_imshow_randomized_axes():
+    plt.close("all")
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
 
@@ -184,6 +213,8 @@ def test_imshow_randomized_axes():
 
 
 def test_imshow_both_orientations():
+    plt.close("all")
+
     s = (
         SimulatedRainbow(R=5, dt=10 * u.minute)
         .inject_transit(planet_radius=0.2)
@@ -204,6 +235,8 @@ def test_imshow_both_orientations():
 
 
 def test_pcolormesh_both_orientations():
+    plt.close("all")
+
     s = (
         SimulatedRainbow(R=5, dt=10 * u.minute)
         .inject_transit(planet_radius=0.2)
@@ -223,6 +256,8 @@ def test_pcolormesh_both_orientations():
 
 
 def test_both_types_of_plot():
+    plt.close("all")
+
     N, M = 10, 20
     r = (
         SimulatedRainbow(
@@ -254,11 +289,20 @@ def test_both_types_of_plot():
 
 
 def test_add_labels_to_panels():
+    plt.close("all")
+
     fi, ax = plt.subplots(3, 3)
     _add_panel_labels(ax, preset="inside", color="blue")
+    plt.savefig(
+        os.path.join(
+            test_directory, "demonstration-of-adding-abcde-labels-to-panels.pdf"
+        )
+    )
 
 
 def test_pcolormesh():
+    plt.close("all")
+
     s = (
         SimulatedRainbow(R=10, dt=10 * u.minute)
         .inject_transit()
@@ -304,6 +348,8 @@ def test_plot_noise_comparison():
 
 
 def test_plot_noise_comparison_in_bins():
+    plt.close("all")
+
     s = SimulatedRainbow(dw=0.1 * u.micron).inject_systematics().inject_noise()
     s.plot_noise_comparison_in_bins()
     plt.savefig(
@@ -314,6 +360,8 @@ def test_plot_noise_comparison_in_bins():
 
 
 def test_plot_histogram():
+    plt.close("all")
+
     s = SimulatedRainbow(R=5).inject_noise()
     fi, ax = plt.subplots(
         s.nwave, 1, figsize=(4, 12), sharex=True, sharey=True, constrained_layout=True

--- a/chromatic/tests/test_visualizations.py
+++ b/chromatic/tests/test_visualizations.py
@@ -20,7 +20,7 @@ def test_imshow():
     fi, ax = plt.subplots(2, 1, sharex=True)
     SimulatedRainbow(R=10).inject_noise().imshow(w_unit="nm", ax=ax[0])
     SimulatedRainbow(dw=0.2 * u.micron).inject_noise().imshow(ax=ax[1], w_unit="nm")
-    plt.savefig(os.path.join(test_directory, "imshow-demonstration.pdf"))
+    plt.savefig(os.path.join(test_directory, "demonstration-of-imshow.pdf"))
 
 
 def test_imshow_quantities():
@@ -28,12 +28,12 @@ def test_imshow_quantities():
     for k in "abcde":
         s.fluxlike[k] = np.random.uniform(4, 5, s.shape)
     s.imshow_quantities(maxcol=1, panel_size=(8, 2))
-    plt.savefig(os.path.join(test_directory, "imshow-multiples-demonstration.pdf"))
+    plt.savefig(os.path.join(test_directory, "demonstration-of-imshow-quantities.pdf"))
 
 
 def test_plot():
     SimulatedRainbow(R=10).inject_noise().plot()
-    plt.savefig(os.path.join(test_directory, "plot-demonstration.pdf"))
+    plt.savefig(os.path.join(test_directory, "demonstration-of-plot.pdf"))
 
 
 def test_plot_unnormalized():
@@ -43,7 +43,12 @@ def test_plot_unnormalized():
         signal_to_noise=5
     )
     s.plot(spacing=0)
-    plt.savefig(os.path.join(test_directory, "plot-demonstration-unnormalized.pdf"))
+    plt.savefig(
+        os.path.join(
+            test_directory,
+            "demonstration-of-plot-without-normalization.pdf",
+        )
+    )
 
 
 def test_plot_quantities():
@@ -58,7 +63,7 @@ def test_plot_quantities():
             plt.savefig(
                 os.path.join(
                     test_directory,
-                    f"plot_quantities-demonstration-data={k}-xaxis={x}.pdf",
+                    f"demonstration-of-plot-quantities-data={k}-xaxis={x}.pdf",
                 )
             )
 
@@ -73,11 +78,15 @@ def test_animate():
     e = d.inject_transit(planet_radius=planet_radius)
     scatterkw = dict()
     e.animate_lightcurves(
-        filename=os.path.join(test_directory, "animate-lightcurves-demonstration.gif"),
+        filename=os.path.join(
+            test_directory, "demonstration-of-animate-lightcurves.gif"
+        ),
         scatterkw=scatterkw,
     )
     e.animate_spectra(
-        filename=os.path.join(test_directory, "animate-spectra-demonstration.gif"),
+        filename=os.path.join(
+            test_directory, "demonstration-of-animate-spectra-demonstration.gif"
+        ),
         scatterkw=scatterkw,
     )
 
@@ -91,12 +100,16 @@ def test_animate_other_quantities():
         .inject_noise(signal_to_noise=1000)
     )
     s.animate_spectra(
-        os.path.join(test_directory, "test-animate-quantities-beside-flux-spectra.gif"),
+        os.path.join(
+            test_directory,
+            "demonstration-of-animate-quantities-beside-flux-spectra.gif",
+        ),
         quantity=k,
     )
     s.animate_lightcurves(
         os.path.join(
-            test_directory, "test-animate-quantities-beside-flux-lightcurves.gif"
+            test_directory,
+            "demonstration-of--animate-quantities-beside-flux-lightcurves.gif",
         ),
         quantity=k,
     )
@@ -125,18 +138,18 @@ def test_plot_one_wavelength():
 
 
 def test_imshow_one_wavelength():
-    s = SimulatedRainbow(wavelength=[1] * u.micron).inject_noise()
-    ax = s.imshow()
-    assert "Wavelength Index" in ax.get_ylabel()
+    with pytest.warns(match="hard to imshow "):
 
-    s = SimulatedRainbow().inject_noise()
-    b = s.bin(nwavelengths=s.nwave)
-    ax = b.imshow()
-    assert "Wavelength (" in ax.get_ylabel()
-    ylim = ax.get_ylim()
-    # assert max(ylim) > max(s.wavelength.value)
-    # assert min(ylim) < min(s.wavelength.value)
-    plt.close("all")
+        s = SimulatedRainbow(wavelength=[1] * u.micron).inject_noise()
+        ax = s.imshow()
+        assert "Wavelength Index" in ax.get_ylabel()
+
+        s = SimulatedRainbow().inject_noise()
+        b = s.bin(nwavelengths=s.nwave)
+        ax = b.imshow()
+        assert "Wavelength (" in ax.get_ylabel()
+        ylim = ax.get_ylim()
+        plt.close("all")
 
 
 def test_imshow_randomized_axes():
@@ -162,6 +175,12 @@ def test_imshow_randomized_axes():
             assert "Time Index" in ax[i].get_xlabel()
         for i in [0, 1]:
             assert "Wavelength Index" in ax[1].get_ylabel()
+        plt.savefig(
+            os.path.join(
+                test_directory,
+                f"demonstration-of-imshow-with-irregular-axes.pdf",
+            )
+        )
 
 
 def test_imshow_both_orientations():
@@ -176,7 +195,12 @@ def test_imshow_both_orientations():
     for i, k in enumerate(["time", "wavelength"]):
         s.plot(ax=ax[0, i], xaxis=k)
         s.imshow(ax=ax[1, i], xaxis=k, colorbar=False)
-    plt.savefig(os.path.join(test_directory, "imshow-both-orientations.png"))
+        plt.savefig(
+            os.path.join(
+                test_directory,
+                f"demonstration-of-imshow-with-both-orientations.pdf",
+            )
+        )
 
 
 def test_pcolormesh_both_orientations():
@@ -191,7 +215,11 @@ def test_pcolormesh_both_orientations():
     for i, k in enumerate(["time", "wavelength"]):
         s.plot(ax=ax[0, i], xaxis=k)
         s.pcolormesh(ax=ax[1, i], xaxis=k, colorbar=False)
-    plt.savefig(os.path.join(test_directory, "pcolormesh-both-orientations.png"))
+    plt.savefig(
+        os.path.join(
+            test_directory, "demonstration-of-pcolormesh-both-orientations.pdf"
+        )
+    )
 
 
 def test_both_types_of_plot():
@@ -215,12 +243,13 @@ def test_both_types_of_plot():
             spacing=0,
             errorbar=True,
             plotkw=dict(color="orchid"),
-            scatterkw=dict(),
             textkw=dict(color="orchid"),
             errorbarkw=dict(color="orchid"),
         )
     plt.savefig(
-        os.path.join(test_directory, "test-plot-lightcurve-and-spectra-many.png")
+        os.path.join(
+            test_directory, "demonstration-of-plot-lightcurves-and-plot-spectra.pdf"
+        )
     )
 
 
@@ -244,7 +273,9 @@ def test_pcolormesh():
     b = s.bin(dw=0.5 * u.micron)
     b.imshow(ax=ax[1, 0])
     b.pcolormesh(ax=ax[1, 1])
-    plt.savefig(os.path.join(test_directory, "test-pcolormesh-vs-imshow.png"))
+    plt.savefig(
+        os.path.join(test_directory, "demonstration-of-pcolormesh-vs-imshow.pdf")
+    )
 
 
 def test_plot_noise_comparison():
@@ -267,13 +298,19 @@ def test_plot_noise_comparison():
         s.plot_noise_comparison(ax=ax[1, i])
     ax[0, 0].set_title("No Systematics")
     ax[0, 1].set_title("With Systematics")
-    plt.savefig(os.path.join(test_directory, "test-plot_noise_comparison.png"))
+    plt.savefig(
+        os.path.join(test_directory, "demonstration-of-plot-noise-comparison.pdf")
+    )
 
 
 def test_plot_noise_comparison_in_bins():
     s = SimulatedRainbow(dw=0.1 * u.micron).inject_systematics().inject_noise()
     s.plot_noise_comparison_in_bins()
-    plt.savefig(os.path.join(test_directory, "test-plot_noise_comparison_in_bins.png"))
+    plt.savefig(
+        os.path.join(
+            test_directory, "demonstration-of-plot-noise-comparison-in-bins.pdf"
+        )
+    )
 
 
 def test_plot_histogram():
@@ -285,4 +322,4 @@ def test_plot_histogram():
         s.plot_histogram(i, ax=ax[i], expected=True)
         if i < (s.nwave - 1):
             plt.xlabel("")
-    plt.savefig(os.path.join(test_directory, "test-histogram.png"))
+    plt.savefig(os.path.join(test_directory, "demonstration-of-histogram.pdf"))

--- a/chromatic/tests/test_withmodel.py
+++ b/chromatic/tests/test_withmodel.py
@@ -27,9 +27,15 @@ def test_imshow_with_models():
         .bin(R=50, dt=5 * u.minute)
     )
     s.imshow_with_models(cmap="gray")
-    plt.savefig(os.path.join(test_directory, "imshow-data-with-model.pdf"))
+    plt.savefig(
+        os.path.join(test_directory, "demonstration-of-imshow-data-with-model.pdf")
+    )
     s.imshow_with_models(models=["systematics_model", "planet_model"], cmap="gray")
-    plt.savefig(os.path.join(test_directory, "imshow-data-with-model-components.pdf"))
+    plt.savefig(
+        os.path.join(
+            test_directory, "demonstration-of-imshow-data-with-model-components.pdf"
+        )
+    )
 
     s.imshow_with_models(models=["systematics_model", "planet_model"], cmap="gray")
     s.imshow_with_models(
@@ -65,7 +71,8 @@ def test_plot_with_model_and_residuals():
         r.plot_with_model_and_residuals(**options)
         plt.savefig(
             os.path.join(
-                test_directory, f"rainbow-of-lightcurves-and-residuals-example{i}.png"
+                test_directory,
+                f"demonstration-of-rainbow-of-lightcurves-and-residuals-example{i}.png",
             )
         )
 
@@ -85,9 +92,13 @@ def test_plot_and_animate_with_models(output="gif"):
             s.plot_one_wavelength_with_models(0, errorbar=e, orientation=o)
             error_string = {True: "with", False: "without"}[e] + "-errorbars"
             filename = f"data-with-models-{o}-{error_string}"
-            plt.savefig(os.path.join(test_directory, f"plot-{filename}.png"))
+            plt.savefig(
+                os.path.join(test_directory, f"demonstration-of-plot-{filename}.png")
+            )
             s.animate_with_models(
-                os.path.join(test_directory, f"animate-{filename}.{output}"),
+                os.path.join(
+                    test_directory, f"demonstration-of-animate-{filename}.{output}"
+                ),
                 errorbar=e,
                 orientation=o,
             )

--- a/chromatic/tests/test_withmodel.py
+++ b/chromatic/tests/test_withmodel.py
@@ -3,6 +3,8 @@ from .setup_tests import *
 
 
 def test_attach_model():
+    plt.close("all")
+
     simulated = SimulatedRainbow().inject_noise().inject_transit().inject_systematics()
     original = simulated._create_copy()
 
@@ -19,6 +21,8 @@ def test_attach_model():
 
 
 def test_imshow_with_models():
+    plt.close("all")
+
     s = (
         SimulatedRainbow()
         .inject_transit()
@@ -52,6 +56,8 @@ def test_imshow_with_models():
 
 
 def test_plot_with_model_and_residuals():
+    plt.close("all")
+
     s = SimulatedRainbow(R=3, dt=3 * u.minute)
     r = s.inject_transit(
         limb_dark="quadratic",
@@ -78,6 +84,7 @@ def test_plot_with_model_and_residuals():
 
 
 def test_plot_and_animate_with_models(output="gif"):
+    plt.close("all")
     s = (
         SimulatedRainbow(R=5)
         .inject_transit()

--- a/chromatic/version.py
+++ b/chromatic/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.11"
+__version__ = "0.3.12"
 
 
 def version():

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup(
         "batman-package>=2.4.9",
         "altair",
         "xarray",
+        "h5py",
     ],
     # what version of Python is required?
     python_requires=">=3.7",  # f-strings are introduced in 3.6!
@@ -107,8 +108,7 @@ setup(
             "mkdocs-exclude",
             "twine",
             "pre-commit",
-        ],
-        "cartoons": ["rainbow-connection>=0.0.7"],
+        ]
     },
     # (I think just leave this set to False)
     zip_safe=False,


### PR DESCRIPTION
This pull request:
- switches MAD calculations from `scipy` to `astropy`, thus running away from a weird error where `scipy` changed the name of the function between versions that users might reasonably have installed in their environments. This closes #185 
- adds a warning for folks trying to bin an unnormalized `Rainbow` object. In some cases it might be fine to do so, but if there are uncertainties that vary significantly between wavelength bins, the current `bin` function will do well only if fluxes are normalized to be close to 1. We should revisit this question later, but for now at least be transparent. This closes #184 , and addresses a problem that @Pat-Wachiraphan ran into with some NIRISS data.
- fixes, hides, and/or explicitly checks most of the expected warnings in the tests. Previously, there were a lot of noisy warnings about things that didn't matter. Having gotten rid of them, there's just one `xarray` deprecation warning that should still be dealt with at some point soon
- changes the formatting for `chromatic`-based warnings to  `🌈 suggestion` (since that's what most of them are) and makes this custom format temporary, so it no longer permanently changes the appearance of warnings coming from other packages or any time after `chromatic` has been imported. This closes #186 
- adds `h5py` to the dependencies, based on @will-waalkes 's recent re-install experience