### PR TITLE
update outlier flagging

### DIFF
--- a/chromatic/rainbows/actions/__init__.py
+++ b/chromatic/rainbows/actions/__init__.py
@@ -7,6 +7,7 @@ from .inject_transit import *
 from .inject_systematics import *
 from .inject_noise import *
 from .inject_spectrum import *
+from .inject_outliers import *
 from .fold import *
 from .flag_outliers import *
 from .compare import *

--- a/chromatic/rainbows/actions/flag_outliers.py
+++ b/chromatic/rainbows/actions/flag_outliers.py
@@ -1,50 +1,72 @@
 from ...imports import *
+from scipy.special import erfc
 
 __all__ = ["flag_outliers"]
 
 
-def flag_outliers(
-    self, sigma = 3
-):
+def flag_outliers(self, how_many_sigma=5, inflate_uncertainty=True):
     """
     Flag outliers on a chromatic rainbow.
 
     Parameters
     ----------
-    sigma : integer
-        Standard deviations (sigmas) allowed for individual data points before they are flagged as outliers.
+    how_many_sigma : float
+        Standard deviations (sigmas) allowed for individual data
+        points before they are flagged as outliers.
+    inflate_uncertainty : bool
+        Should uncertainties per wavelength be inflated to
+        match the (MAD-based) standard deviation of the data?
 
     Returns
     -------
     rainbow : Rainbow
-        A new Rainbow object with the outliers flagged as 0's in the 'ok' array.
+        A new Rainbow object with the outliers flagged as 0 in `.ok`
     """
 
-    
     # create a history entry for this action (before other variables are defined)
     h = self._create_history_entry("flag_outliers", locals())
-    
+
     # create a copy of the existing rainbow
     new = self._create_copy()
-    
-    list_of_rows = []
-    for i, row in enumerate(new.flux):
-        diffs = np.diff(row)
-        mask = sigma_clip(diffs, sigma=sigma, maxiters=5, cenfunc = 'median')
-        
-        ls = np.hstack((np.asarray([True]),~mask.mask))
-        new_ls = ls.copy()
-        for i in range(1,len(ls)):
-            if ((ls[i] == True) and (ls[i-1] == False)):
-                new_ls[i-1] = True
-                
-        list_of_rows.append(new_ls)
-            
-    full_mask = np.array(list_of_rows)
 
-    new.ok = new.ok * full_mask  
-        
+    # how many outliers are expected from noise alone
+    outliers_expected_from_normal_distribution = erfc(how_many_sigma) * self.nflux * 2
+    if outliers_expected_from_normal_distribution >= 1:
+        cheerfully_suggest(
+            f"""
+        When drawing from a normal distribution, an expected {outliers_expected_from_normal_distribution:.1f} out of
+        the total {self.nflux} datapoints in {self} would be marked
+        as a >{how_many_sigma} sigma outlier.
+
+        If you don't want to accidentally clip legitimate data points that
+        might have arisen merely by chance, please consider setting the
+        outlier flagging threshold (`sigma=`) to a larger value.
+        """
+        )
+
+    # create a trend-filtered object and use it to find outliers
+    filtered = new.remove_trends(method="median_filter", size=(3, 5))
+    if np.all(filtered.uncertainty == 0):
+        filtered.uncertainty = (
+            np.ones(filtered.shape)
+            * filtered.get_measured_scatter(method="MAD")[:, np.newaxis]
+        )
+        inflate_uncertainty = False
+
+    # inflate the per-wavelength uncertainties, as needed
+    if inflate_uncertainty:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            inflated = filtered.inflate_uncertainty(method="MAD")
+    else:
+        inflated = filtered
+    is_outlier = np.abs(inflated.flux - 1) > how_many_sigma * inflated.uncertainty
+
+    # update the output object
+    new.fluxlike["flagged_as_outlier"] = is_outlier
+    new.ok = new.ok * (is_outlier == False)
+
     # append the history entry to the new Rainbow
     new._record_history_entry(h)
-    
+
     return new

--- a/chromatic/rainbows/actions/inject_outliers.py
+++ b/chromatic/rainbows/actions/inject_outliers.py
@@ -1,0 +1,48 @@
+from ...imports import *
+
+__all__ = ["inject_outliers"]
+
+
+def inject_outliers(self, fraction=0.01, amplitude=10):
+    """
+    Inject some random outliers.
+
+    Parameters
+    ----------
+    fraction : float
+        The fraction of pixels that should get outliers.
+        (default = 0.01)
+    amplitude : float
+        If uncertainty > 0, how many sigma should outliers be?
+        If uncertainty = 0, what number should be injected?
+        (default = 10)
+
+    Returns
+    -------
+    rainbow : Rainbow
+        A new Rainbow object with outliers injected.
+    """
+
+    # create a history entry for this action (before other variables are defined)
+    h = self._create_history_entry("inject_outliers", locals())
+
+    # create a copy of the existing Rainbow
+    new = self._create_copy()
+
+    # pick some random pixels to inject outliers
+    outliers = np.random.uniform(0, 1, self.shape) < fraction
+
+    # inject outliers based on uncertainty if possible
+    if np.any(self.uncertainty > 0):
+        new.fluxlike["injected_outliers"] = outliers * amplitude * self.uncertainty
+    else:
+        new.fluxlike["injected_outliers"] = outliers * amplitude
+
+    # modify the flux
+    new.fluxlike["flux"] += new.fluxlike["injected_outliers"]
+
+    # append the history entry to the new Rainbow
+    new._record_history_entry(h)
+
+    # return the new object
+    return new

--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -948,6 +948,7 @@ class Rainbow:
         inject_systematics,
         inject_noise,
         inject_spectrum,
+        inject_outliers,
         flag_outliers,
         fold,
         mask_transit,

--- a/chromatic/tests/__init__.py
+++ b/chromatic/tests/__init__.py
@@ -19,3 +19,4 @@ from .test_spectra import *
 from .test_remove_trends import *
 from .test_time import *
 from .test_fold import *
+from .test_outliers import *

--- a/chromatic/tests/test_outliers.py
+++ b/chromatic/tests/test_outliers.py
@@ -1,0 +1,28 @@
+from ..rainbows import *
+from .setup_tests import *
+
+
+def test_flag_outliers():
+    noiseless = SimulatedRainbow(R=10, dt=10 * u.minute).inject_transit()
+    noiseless_outliers = noiseless.inject_outliers()
+    noiseless_flagged = noiseless_outliers.flag_outliers()
+
+    noisy = SimulatedRainbow(R=10, dt=10 * u.minute).inject_transit().inject_noise()
+    noisy_outliers = noisy.inject_outliers()
+    noisy_flagged = noisy_outliers.flag_outliers()
+
+    kw = dict(vmin=0.9, vmax=1.1)
+    fi, ax = plt.subplots(2, 3, figsize=(10, 4), dpi=300)
+    noisy.imshow(ax=ax[0, 0], **kw)
+    noisy_outliers.imshow(ax=ax[0, 1], **kw)
+    noisy_flagged.imshow(ax=ax[0, 2], **kw)
+
+    noiseless.imshow(ax=ax[1, 0], **kw)
+    noiseless_outliers.imshow(ax=ax[1, 1], **kw)
+    noiseless_flagged.imshow(ax=ax[1, 2], **kw)
+
+    plt.savefig(os.path.join(test_directory, "demonstration-of-flagging-outliers.pdf"))
+    assert np.all(
+        (noisy_flagged.fluxlike["injected_outliers"] != 0)
+        == noisy_flagged.fluxlike["flagged_as_outlier"]
+    )

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -122,7 +122,7 @@
    "id": "5cf32700",
    "metadata": {},
    "source": [
-    "What a transit! Let's bin these data to very low resolution ($R = \\lambda/\\Delta \\lambda = 10$), fold the times onto the period and transit epoch for [WASP-96b](https://exoplanetarchive.ipac.caltech.edu/overview/WASP-96b), and plot the data as a series of stacked transit light curves."
+    "What a transit! Let's flag outlying data points, bin the data to very low resolution ($R = \\lambda/\\Delta \\lambda = 10$), fold the times onto the period and transit epoch for [WASP-96b](https://exoplanetarchive.ipac.caltech.edu/overview/WASP-96b), and plot the data as a series of stacked transit light curves."
    ]
   },
   {
@@ -134,6 +134,7 @@
    "source": [
     "(\n",
     "    rainbow.normalize()\n",
+    "    .flag_outliers()\n",
     "    .bin(R=10)\n",
     "    .fold(period=3.4252577 * u.day, t0=2459111.30170 * u.day)\n",
     "    .plot()\n",


### PR DESCRIPTION
This pull request:
- makes some small updates to `flag_outliers` to make better use of `remove_trends` and estimated uncertainties
- add `.inject_outliers`
- add test for `flag_outliers` to check we correctly flag outliers that have been injected
- add outlier flagging to the `quickstart.ipynb` documentation page

It closes #166 . Thanks @kortizceballos for all the great work on this!