### PR TITLE
remove dependency on `batman`; switch to trapezoidal transit as default

### DIFF
--- a/chromatic/rainbows/actions/inject_transit.py
+++ b/chromatic/rainbows/actions/inject_transit.py
@@ -4,81 +4,232 @@ import batman
 __all__ = ["inject_transit"]
 
 
-def inject_transit(self, planet_radius=0.1, **planet_params):
+def trapezoidal_transit(t, delta=0.01, P=1, t0=0, T=0.1, tau=0.01, baseline=1.0):
+
+    """
+    One dimensional Trapezoid Transit model,
+    using the symbols defined for a circular
+    transit approximation in Winn (2010).
+
+    This is a fittable astropy model.
+
+    Parameters
+    ----------
+    delta : float
+        The depth of the transit, as a fraction of the out-of-transit flux.
+    P : float
+        The period of the planet, in days.
+    t0 : float
+        Mid-transit time of the transit, in days.
+    T : float
+        The duration of the transit (from mid-ingress to mid-egress), in days.
+    tau : float
+        The duration of ingress/egress, in days.
+    baseline : float
+        The baseline, out-of-transit flux level.
+
+    Examples
+    --------
+    .. plot::
+        :include-source:
+
+        import numpy as np
+        import matplotlib.pyplot as plt
+
+        from henrietta.fitting import TrapezoidTransit
+
+        plt.figure()
+        model = TrapezoidTransit()
+        t = np.arange(-5, 5, .01)
+
+        for x in np.linspace(0.02, 0.2, 4):
+            model.delta = x
+            model.T = x
+            plt.plot(t, model(t), lw=2)
+
+        plt.show()
+    """
+
+    # calculate a phase-folded time (still in units of days)
+    x = (t - t0 + 0.5 * P) % P - 0.5 * P
+
+    # Compute the four points where the trapezoid changes slope
+    # x1 <= x2 <= x3 <= x4
+
+    if tau > T:
+        x1 = -tau
+        x2 = 0
+        x3 = 0
+        x4 = tau
+    else:
+        x1 = -(T + tau) / 2.0
+        x2 = -(T - tau) / 2.0
+        x3 = (T - tau) / 2.0
+        x4 = (T + tau) / 2.0
+
+    # Compute model values in pieces between the change points
+    range_a = np.logical_and(x >= x1, x < x2)
+    range_b = np.logical_and(x >= x2, x < x3)
+    range_c = np.logical_and(x >= x3, x < x4)
+
+    if tau == 0:
+        slope = np.inf
+    else:
+        slope = delta / tau
+    val_a = 1 - slope * (x - x1)
+    val_b = 1 - delta
+    val_c = 1 - slope * (x4 - x)
+    result = (
+        np.select([range_a, range_b, range_c], [val_a, val_b, val_c], default=1)
+        * baseline
+    )
+    return result
+
+
+def exoplanetcore_transit(*args, **kwargs):
+    raise NotImplementedError(
+        "The `exoplanet-core` transit option isn't available yet. Sorry!"
+    )
+
+
+def inject_transit(
+    self, depth=0.01, radius_ratio=None, method="trapezoid", **transit_parameters
+):
 
     """
     Simulate a wavelength-dependent planetary transit.
 
-    This uses `batman` to inject a transit model into
-    the `Rainbow`, allowing each wavelength to have a
-    separate planet radius (for example caused by
-    absorption in the planet's atmosphere).
+    This uses one of a few methods to inject a transit
+    signal into the `Rainbow`, allowing the transit
+    depth to change with wavelength (for example due to a
+    planet's effective radius changing with wavelength due
+    to its atmospheric transmission spectrum). Other
+    parameters can also be wavlength-dependent, but
+    some (like period, inclination, etc...) probably
+    shouldn't be.
+
+    The current methods include:
+
+    `'trapezoid'` to inject a cartoon transit, using nomenclature
+    from [Winn (2010)](https://arxiv.org/abs/1001.2010).
+    This is the default method, to avoid package dependencies
+    that can be finicky to compile and/or install on different
+    operating systems.
+
+    `'batman'` to inject a limb-darkened transit using [batman-package](https://lkreidberg.github.io/batman/docs/html/index.html)
+    This method requires that `batman-package` be installed,
+    and it will try to throw a helpful warning message if
+    it's not.
+
+    `'exoplanet-core'` to inject a limb-darkened transit using [exoplanet-core](https://github.com/exoplanet-dev/exoplanet-core).
+    This option is still under developed. Coming soon! We hope
+    this will be the best of both worlds, prodiving a limb-darkened
+    transit without scary installation dependencies.
 
     Parameters
     ----------
-    planet_radius : float, array
-        Two options:
-            1D array with same dimensions as wavelength array,
-                with each value corresponding to Rp/Rs at that wavelength.
-            float representing Rp/Rs if the radius is not wavelength-dependent.
-        example value: planet_radius = 0.01,
-    **planet_params : dict
-        All other keywords will be interpreted as other planet parameters.
-        Values for planetary parameters for use in batman modelling.
-        Any values not supplied will be set to defaults:
-            "t0" = time of inferior conjunction (days) (default 0)
-            "per" = orbital period (days) (detault 1)
-            "a" = semi-major axis (units of stellar radii) (default 15)
-            "inc" = inclination (degrees) (default 90)
-            "ecc" = eccentricity (default 0)
-            "w" = longitude of periastron (degrees)(default 0)
-            "limb_dark" = limb-darkening model (default "nonlinear"), possible
-                values described in more detail in batman documentation
-            "u" = limb-darkening coefficients (default [0.5, 0.1, 0.1, -0.1])
-                Can take 3 forms:
-                -A single value (if limb-darkening law requires only one value)
-                -A 1D list/array of coefficients corresponding to the limb-darkening
-                law
-                -A 2D array of the form (n_wavelengths, n_coefficients) where
-                each row is the set of limb-darkening coefficients corresponding
-                to a single wavelength
-                Note that this currently does not calculate the appropriate
-                coefficient vs wavelength variations itself- there exist codes
-                (such as hpparvi/PyLDTk and nespinoza/limb-darkening) which
-                can be used for this.
+    depth : float, array, None
+        The transit depth = [(planet radius)/(star radius)]**2,
+        which can be either a single value for all wavelengths,
+        or an array with one value for each wavelength.
+        Only one of [`depth`, `radius_ratio`] can be not None.
+        (default 0.01)
+    radius_ratio : float, array, None
+        The planet-to-star radius ratio = [transit depth]**0.5,
+        which can be either a single value for all wavelengths,
+        or an array with one value for each wavelength.
+        Only one of [`depth`, `radius_ratio`] can be not None.
+        (default None)
+    method : str
+        What method should be used to inject the transits? Different
+        methods will produce different results and have different options.
+        The currently implement options are `'trapezoid'` and `'batman'`.
+    **transit_parameters : dict
+        All additional keywords will be passed to the transit model.
+        The accepted keywords for the different methods are as follows.
+            `'trapezoid'` accepts the following keyword arguments:
+                "delta" = The depth of the transit, as a fraction of the out-of-transit flux (default 0.01)
+                "P" = The orbital period of the planet, in days (default 1.0)
+                "t0" = Mid-transit time of the transit, in days (default 0.0)
+                "T" = The duration of the transit (from mid-ingress to mid-egress), in days (default 0.1)
+                "tau" = The duration of ingress/egress, in days (default 0.01)
+                "baseline" = The baseline, out-of-transit flux level (default 1.0)
+            `batman` accepts the following keyword arguments:
+                "rp" = (planet radius)/(star radius), unitless (default 0.1)
+                "t0" = Mid-transit time of the transit, in days (default 0.0)
+                "per" = The orbital period of the planet, in days (default 1.0)
+                "a" = (semi-major axis)/(star radius), unitless (default 10)
+                "inc" = The orbital inclination, in degrees (default 90)
+                "ecc" = The orbital eccentricity, unitless (default 0.0)
+                "w" = The longitude of periastron, in degrees (default 0.0)
+                "limb_dark" = The limb-darkening model (default "quadratic"), possible
+                    values described in more detail in batman documentation.
+                "u" = The limb-darkening coefficients (default [0.2, 0.2])
+                    These coefficients can be:
+                        -one value (if limb-darkening law requires only one value)
+                        -a 1D list/array of coefficients for constant limb-darkening
+                        -a 2D array of the form (n_wavelengths, n_coefficients) where
+                        each row is the set of limb-darkening coefficients corresponding
+                        to a single wavelength
+                    Note that this currently does not calculate the appropriate
+                    coefficient vs wavelength variations itself-there exist codes
+                    (such as hpparvi/PyLDTk and nespinoza/limb-darkening) which
+                    can be used for this.
     """
 
-    # create a history entry for this action (before other variables are defined)
+    '''# create a history entry for this action (before other variables are defined)
     h = self._create_history_entry("inject_transit", locals())
-    h = h.replace("planet_params={", "**{")
+    h = h.replace("transit_parameters={", "**{")
+
+    if ((depth == None) and (radius_ratio == None)) or ((depth ! None) and (radius_ratio != None)):
+        raise ValueError(
+            f"""
+        You appear to have called `inject_transit` with
+        the following inputs:
+            depth={depth}
+            radius_ratio={radius_ratio}
+        Exactly one of these needs to be set,
+        and the other needs to be None.
+        """
+        )
 
     # create a copy of the existing Rainbow
     new = self._create_copy()
 
-    # First, make sure planet_radius has the right dimension.
+    # Defaults for planet simulation.
+    if method == "trapezoid":
+        defaults = {
+            "delta": 0.01,
+            "P": 1.0,
+            "t0": 0.0,
+            "T": 0.1,
+            "tau": 0.01,
+            "baseline": 1.0,
+        }
+    elif method == "batman":
+        defaults = {
+            "t0": 0.0,
+            "per": 1.0,
+            "a": 10.0,
+            "inc": 90.0,
+            "ecc": 0.0,
+            "w": 0.0,
+            "limb_dark": "quadratic",
+            "u": [0.2, 0.2],
+        }
+
+    # first, make sure depth has the right dimensions
     if type(planet_radius) != float and len(planet_radius) != self.nwave:
         print(
             "Invalid planet radius array: must be float or have shape "
             + str(np.shape(self.wavelike["wavelength"]))
         )
 
-    # Defaults for planet simulation.
-    defaults = {
-        "t0": 0,
-        "per": 3,
-        "a": 10,
-        "inc": 90,
-        "ecc": 0,
-        "w": 0,
-        "limb_dark": "nonlinear",
-        "u": [0.5, 0.1, 0.1, -0.1],
-    }
-
     # Read in planet parameters.
-    for i in range(len(planet_params.keys())):
-        key = list(planet_params.keys())[i]
+    for i in range(len(transit_parameters.keys())):
+        key = list(transit_parameters.keys())[i]
         if key in list(defaults.keys()):
-            defaults[key] = planet_params[key]
+            defaults[key] = transit_parameters[key]
         else:
             print("Warning: " + str(key) + " not a valid parameter")
 
@@ -144,3 +295,4 @@ def inject_transit(self, planet_radius=0.1, **planet_params):
 
     # return the new object
     return new
+'''

--- a/chromatic/tests/test_fold.py
+++ b/chromatic/tests/test_fold.py
@@ -14,7 +14,7 @@ def test_fold(N=5):
         N = np.random.randint(-10, 10)
         s = (
             SimulatedRainbow(time=original_time + t0 + period * N, R=5)
-            .inject_transit(per=period.to_value("day"), t0=t0.to_value("day"))
+            .inject_transit(P=period.to_value("day"), t0=t0.to_value("day"))
             .inject_noise(signal_to_noise=1000)
         )
         f = s.fold(period=period, t0=t0)

--- a/chromatic/tests/test_withmodel.py
+++ b/chromatic/tests/test_withmodel.py
@@ -64,6 +64,7 @@ def test_plot_with_model_and_residuals():
         u=np.transpose(
             [np.linspace(1.0, 0.0, s.nwave), np.linspace(0.5, 0.0, s.nwave)]
         ),
+        method="batman",
     ).inject_noise(signal_to_noise=1000)
     for i, options in enumerate(
         [

--- a/chromatic/version.py
+++ b/chromatic/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.15"
+__version__ = "0.3.16"
 
 
 def version():

--- a/docs/actions.ipynb
+++ b/docs/actions.ipynb
@@ -62,7 +62,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It's useful to have a way to inject a simulated transit of an imaginary exoplanet. If you're trying out some new fitting algorithm, you can inject a transit with known properties and make sure you recover it!"
+    "It's useful to have a way to inject a simulated transit of an imaginary exoplanet. If you're trying out some new fitting algorithm, you can inject a transit with known properties and make sure you recover it. "
    ]
   },
   {
@@ -96,7 +96,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The parameters used for the transit model will be stored in `.metadata['transit_parameters']`."
+    "The parameters used for the transit model will be stored in `.metadata['injected_transit_parameters']`."
    ]
   },
   {

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,6 @@ setup(
         "astropy>=4.0",
         "pandas",
         "tqdm",
-        "batman-package>=2.4.9",
         "altair",
         "xarray",
         "h5py",
@@ -109,7 +108,9 @@ setup(
             "mkdocs-exclude",
             "twine",
             "pre-commit",
-        ]
+            "batman-package>=2.4.9",
+        ],
+        "modeling": ["batman-package>=2.4.9"],
     },
     # (I think just leave this set to False)
     zip_safe=False,


### PR DESCRIPTION
This:
- adds options `'trapezoid'` and `'batman` to the `inject_transit` action
- implements the simple trapezoidal transit used in Winn (2010) Transit + Occultations
- removes the explicit dependency on `batman-package`, now just raising a warning and a suggestion to install it if needed