### PR TITLE
use `ok` in `normalize`

### DIFF
--- a/chromatic/rainbows/actions/normalization.py
+++ b/chromatic/rainbows/actions/normalization.py
@@ -85,11 +85,11 @@ def normalize(self, axis="wavelength", percentile=50):
         fix = {
             "w": """
                 ok = rainbow.get_median_spectrum() > 0
-                rainbow[ok, :]
+                rainbow[ok, :].normalize()
         """,
             "t": """
                 ok = rainbow.get_median_lightcurve() > 0
-                rainbow[:, ok]
+                rainbow[:, ok].normalize()
         """,
         }[a]
         if np.any(normalization < 0):

--- a/chromatic/rainbows/actions/normalization.py
+++ b/chromatic/rainbows/actions/normalization.py
@@ -44,12 +44,20 @@ def normalize(self, axis="wavelength", percentile=50):
     # create an empty copy
     new = self._create_copy()
 
+    # shortcut for the first letter of the axis
+    a = axis.lower()[0]
+
     # (ignore nan warnings)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
 
-        if axis.lower()[0] == "w":
-            normalization = np.nanpercentile(new.flux, percentile, axis=self.timeaxis)
+        # get fluxes, with not-OK replaced with nans
+        flux_for_normalizing = new.get_ok_data()
+        negative_normalization_message = ""
+        if a == "w":
+            normalization = np.nanpercentile(
+                flux_for_normalizing, percentile, axis=self.timeaxis
+            )
             for k in self._keys_that_respond_to_math:
                 new.fluxlike[k] = new.get(k) / normalization[:, np.newaxis]
             try:
@@ -58,8 +66,11 @@ def normalize(self, axis="wavelength", percentile=50):
                 )
             except ValueError:
                 pass
-        elif axis.lower()[0] == "t":
-            normalization = np.nanpercentile(self.flux, percentile, axis=self.waveaxis)
+
+        elif a == "t":
+            normalization = np.nanpercentile(
+                flux_for_normalizing, percentile, axis=self.waveaxis
+            )
             for k in self._keys_that_respond_to_math:
                 new.fluxlike[k] = new.get(k) / normalization[np.newaxis, :]
             try:
@@ -68,6 +79,33 @@ def normalize(self, axis="wavelength", percentile=50):
                 )
             except ValueError:
                 pass
+
+    if a in "wt":
+        thing = {"w": "wavelengths", "t": "times"}[a]
+        fix = {
+            "w": """
+                ok = rainbow.get_median_spectrum() > 0
+                rainbow[ok, :]
+        """,
+            "t": """
+                ok = rainbow.get_median_lightcurve() > 0
+                rainbow[:, ok]
+        """,
+        }[a]
+        if np.any(normalization < 0):
+            cheerfully_suggest(
+                f"""
+            There are {np.sum(normalization < 0)} negative {thing} that
+            are going into the normalization of this Rainbow. If you're
+            not expecting negative fluxes, it may be useful to trim them
+            away with something like:
+
+            {fix}
+
+            Otherwise, watch out that your fluxes and uncertainties may
+            potentially have flipped sign!
+            """
+            )
 
     # append the history entry to the new Rainbow
     new._record_history_entry(h)

--- a/chromatic/rainbows/get/fluxlike/__init__.py
+++ b/chromatic/rainbows/get/fluxlike/__init__.py
@@ -1,0 +1,1 @@
+from .subset import *

--- a/chromatic/rainbows/get/fluxlike/subset.py
+++ b/chromatic/rainbows/get/fluxlike/subset.py
@@ -1,0 +1,41 @@
+from ....imports import *
+
+__all__ = [
+    "get_ok_data",
+]
+
+
+def get_ok_data(
+    self,
+    y="flux",
+    minimum_acceptable_ok=1,
+):
+    """
+    A small wrapper to get the good data as a 2D array.
+
+    Extract fluxes as 2D array, marking data that are not `ok`
+    either as nan or by inflating uncertainties to infinity.
+
+    Parameters
+    ----------
+    y : array
+        The desired quantity (default is `flux`)
+    minimum_acceptable_ok : float, optional
+        The smallest value of `ok` that will still be included.
+        (1 for perfect data, 1e-10 for everything but terrible data, 0 for all data)
+
+    Returns
+    -------
+    flux : array
+        The fluxes, but with not-OK data replaced with nan.
+    """
+    # get 1D array of what to keep
+    ok = self.ok >= minimum_acceptable_ok
+
+    # create copy of flux array
+    y = self.get(y) * 1
+
+    # set bad values to nan
+    y[ok == False] = np.nan
+
+    return y

--- a/chromatic/rainbows/get/timelike/median_lightcurve.py
+++ b/chromatic/rainbows/get/timelike/median_lightcurve.py
@@ -14,4 +14,4 @@ def get_median_lightcurve(self):
     """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        return np.nanmedian(self.flux, axis=0)
+        return np.nanmedian(self.get_ok_data(), axis=0)

--- a/chromatic/rainbows/get/wavelike/median_spectrum.py
+++ b/chromatic/rainbows/get/wavelike/median_spectrum.py
@@ -14,4 +14,4 @@ def get_median_spectrum(self):
     """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        return np.nanmedian(self.flux, axis=1)
+        return np.nanmedian(self.get_ok_data(), axis=1)

--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -1005,7 +1005,7 @@ class Rainbow:
         get_ok_data_for_wavelength,
     )
 
-    # import summary statistics for each wavelength
+    # import summary statistics for each time
     from .get.timelike import (
         get_average_lightcurve,
         get_median_lightcurve,
@@ -1013,6 +1013,11 @@ class Rainbow:
         get_ok_data_for_time,
         get_times_as_astropy,
         set_times_from_astropy,
+    )
+
+    # import summary statistics for each time
+    from .get.fluxlike import (
+        get_ok_data,
     )
 
     # import visualizations that can act on Rainbows

--- a/chromatic/tests/test_normalize.py
+++ b/chromatic/tests/test_normalize.py
@@ -30,6 +30,30 @@ def test_normalize(plot=False):
     plt.close("all")
 
 
+def test_normalization_negative_warnings():
+    snr = 0.1
+    rainbow = SimulatedRainbow().inject_noise(signal_to_noise=0.1)
+
+    with pytest.warns(match="get_median_spectrum"):
+        rainbow.normalize(axis="wavelength")
+    ok = rainbow.get_median_spectrum() > 0
+    rainbow[ok, :].normalize(axis="wavelength")
+
+    with pytest.warns(match="get_median_lightcurve"):
+        rainbow.normalize(axis="time")
+    ok = rainbow.get_median_lightcurve() > 0
+    rainbow[:, ok].normalize(axis="time")
+
+
+def test_normalization_with_not_ok():
+    snr = 0.1
+    rainbow = SimulatedRainbow().inject_noise(signal_to_noise=0.1)
+    rainbow.ok = rainbow.flux > 0
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        rainbow.normalize()
+
+
 def test_is_probably_normalized():
     f = [2] * u.W / u.m**2
     kw = dict(star_flux=f, R=10, dt=10 * u.minute)

--- a/chromatic/version.py
+++ b/chromatic/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 
 
 def version():


### PR DESCRIPTION
- Add `get_ok_data` as (possibly pointless) wrapper to get flux with bad data replaced with `nan`.
- Fix `normalize` to now use `ok`. 
- Add warning to `normalize` if any of the normalization factors are negative, with suggestion for fix. 
- Add more tests for `normalize`.
Closes #222 . Passes tests.