### PR TITLE
add "easy" concatenate options

### DIFF
--- a/chromatic/rainbows/actions/__init__.py
+++ b/chromatic/rainbows/actions/__init__.py
@@ -14,3 +14,4 @@ from .compare import *
 from .remove_trends import *
 from .attach_model import *
 from .inflate_uncertainty import *
+from .concatenate import *

--- a/chromatic/rainbows/actions/concatenate.py
+++ b/chromatic/rainbows/actions/concatenate.py
@@ -54,11 +54,24 @@ def concatenate_in_time(self, other, maximum_fractional_difference=0.01):
 
     # loop through timelike quantities
     for k in self.timelike:
-        new.timelike[k] = np.hstack([self.timelike[k], other.timelike[k]])
-
+        try:
+            new.timelike[k] = np.hstack([self.timelike[k], other.timelike[k]])
+        except (KeyError, AttributeError):
+            cheerfully_suggest(
+                f"""
+            .timelike['{k}'] didn't exist for one of the objects; not merging.
+            """
+            )
     # loop through fluxlike quantities
     for k in self.fluxlike:
-        new.fluxlike[k] = np.hstack([self.fluxlike[k], other.fluxlike[k]])
+        try:
+            new.fluxlike[k] = np.hstack([self.fluxlike[k], other.fluxlike[k]])
+        except (KeyError, AttributeError):
+            cheerfully_suggest(
+                f"""
+            .fluxlike['{k}'] didn't exist for one of the objects; not merging.
+            """
+            )
 
     # append the history entry to the new Rainbow
     new._record_history_entry(h)
@@ -106,11 +119,25 @@ def concatenate_in_wavelength(self, other, maximum_fractional_difference=0.01):
 
     # loop through wavelike quantities
     for k in self.wavelike:
-        new.wavelike[k] = np.hstack([self.wavelike[k], other.wavelike[k]])
+        try:
+            new.wavelike[k] = np.hstack([self.wavelike[k], other.wavelike[k]])
+        except (KeyError, AttributeError):
+            cheerfully_suggest(
+                f"""
+            .wavelike['{k}'] didn't exist for one of the objects; not merging.
+            """
+            )
 
     # loop through fluxlike quantities
     for k in self.fluxlike:
-        new.fluxlike[k] = np.hstack([self.fluxlike[k], other.fluxlike[k]])
+        try:
+            new.fluxlike[k] = np.hstack([self.fluxlike[k], other.fluxlike[k]])
+        except (KeyError, AttributeError):
+            cheerfully_suggest(
+                f"""
+            .fluxlike['{k}'] didn't exist for one of the objects; not merging.
+            """
+            )
 
     # append the history entry to the new Rainbow
     new._record_history_entry(h)

--- a/chromatic/rainbows/actions/concatenate.py
+++ b/chromatic/rainbows/actions/concatenate.py
@@ -1,0 +1,119 @@
+from ...imports import *
+
+# FIXME:
+# - include more careful handling of different keys in different rainbows
+# - write more flexible `concatenate_flexibly` (?) to allow different wavelengths *and* times
+# - write wrapper `concatenate` to choose the approproate concatenator
+# - think about what to do with merged histories?
+
+__all__ = ["concatenate_in_time", "concatenate_in_wavelength"]
+
+
+def fractional_difference(a, b):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return np.abs((a - b) / (a + b) * 2)
+
+
+def concatenate_in_time(self, other, maximum_fractional_difference=0.01):
+    """
+    Merge another Rainbow into this one,
+    assuming their wavelengths are *exactly* the same.
+
+    Parameters
+    ----------
+    other : Rainbow
+       The other Rainbow to merge into this one.
+
+    maximum_fractional_difference : float
+        If the fractional difference between arrays that
+        should be the same (such as wavelength) exceeds
+        this amount, the user will be warned about it.
+    """
+
+    # create a history entry for this action (before other variables are defined)
+    h = self._create_history_entry("concatenate_in_time", locals())
+
+    # make sure wavelength grid shapes match, at least
+    assert self.nwave == other.nwave
+
+    # create an exact copy of the first object
+    new = self._create_copy()
+
+    # loop through wavelengths
+    for k in self.wavelike:
+        f = fractional_difference(self.wavelike[k], other.wavelike[k])
+        if np.any(f > maximum_fractional_difference):
+            cheerfully_suggest(
+                f"""
+            wavelike['{k}'] differs fractionally by a maximum of {np.max(f):.3g}
+            between `self` and `other` ({np.sum(f > maximum_fractional_difference)} differences greater than {maximum_fractional_difference:.3g}).
+            `self` values will be used; `other` values will be ignored.
+            """
+            )
+
+    # loop through timelike quantities
+    for k in self.timelike:
+        new.timelike[k] = np.hstack([self.timelike[k], other.timelike[k]])
+
+    # loop through fluxlike quantities
+    for k in self.fluxlike:
+        new.fluxlike[k] = np.hstack([self.fluxlike[k], other.fluxlike[k]])
+
+    # append the history entry to the new Rainbow
+    new._record_history_entry(h)
+
+    # return the new Rainbow
+    return new
+
+
+def concatenate_in_wavelength(self, other, maximum_fractional_difference=0.01):
+    """
+    Merge another Rainbow into this one,
+    assuming their times are *exactly* the same.
+
+    Parameters
+    ----------
+    other : Rainbow
+       The other Rainbow to merge into this one.
+
+    maximum_fractional_difference : float
+        If the fractional difference between arrays that
+        should be the same (such as time) exceeds
+        this amount, the user will be warned about it.
+    """
+
+    # create a history entry for this action (before other variables are defined)
+    h = self._create_history_entry("concatenate_in_wavelength", locals())
+
+    # make sure wavelength grid shapes match, at least
+    assert self.ntime == other.ntime
+
+    # create an exact copy of the first object
+    new = self._create_copy()
+
+    # loop through times
+    for k in self.timelike:
+        f = fractional_difference(self.timelike[k], other.timelike[k])
+        if np.any(f > maximum_fractional_difference):
+            cheerfully_suggest(
+                f"""
+            timelike['{k}'] differs fractionally by a maximum of {np.max(f):.3g}
+            between `self` and `other` ({np.sum(f > maximum_fractional_difference)} differences greater than {maximum_fractional_difference:.3g}).
+            `self` values will be used; `other` values will be ignored.
+            """
+            )
+
+    # loop through wavelike quantities
+    for k in self.wavelike:
+        new.wavelike[k] = np.hstack([self.wavelike[k], other.wavelike[k]])
+
+    # loop through fluxlike quantities
+    for k in self.fluxlike:
+        new.fluxlike[k] = np.hstack([self.fluxlike[k], other.fluxlike[k]])
+
+    # append the history entry to the new Rainbow
+    new._record_history_entry(h)
+
+    # return the new Rainbow
+    return new

--- a/chromatic/rainbows/actions/descriptions.txt
+++ b/chromatic/rainbows/actions/descriptions.txt
@@ -4,6 +4,8 @@ cartoon | name | description
 🌈🚧🌊 | align_wavelengths | Align spectra with different wavelength grids onto one shared axis.
 🌈🧺🧱 | bin | Bin to a new wavelength or time grid.
 🌈🧑‍🤝‍🧑🌈 | compare | Connect to other 🌈 objects for easy comparison.
+🌈🐈⏰ | concatenate_in_time | Stitch together two Rainbows with identical wavelengths.
+🌈🐈🌊 | concatenate_in_wavelength | Stitch together two Rainbows with identical times.
 🌈🚩👀 | flag_outliers | Flag outlier data points.
 🌈⏲🎞 | fold | Fold times relative to a particular period and epoch.
 🌈🧺⏰ | get_average_lightcurve_as_rainbow | Bin down to a single integrated light curve.

--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -1026,6 +1026,7 @@ class Rainbow:
     from .visualizations import (
         imshow,
         pcolormesh,
+        scatter,
         plot_lightcurves,
         _setup_animate_lightcurves,
         animate_lightcurves,

--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -991,6 +991,8 @@ class Rainbow:
         remove_trends,
         attach_model,
         inflate_uncertainty,
+        concatenate_in_time,
+        concatenate_in_wavelength,
     )
 
     # import summary statistics for each wavelength

--- a/chromatic/rainbows/visualizations/__init__.py
+++ b/chromatic/rainbows/visualizations/__init__.py
@@ -6,10 +6,12 @@ from .diagnostics import *
 
 from .colors import *
 from .imshow import *
+from .scatter import *
+from .pcolormesh import *
+
 from .plot_lightcurves import *
 from .animate import *
 from .interactive import *
 from .plot_spectra import *
 from .plot import *
 from .utilities import *
-from .pcolormesh import *

--- a/chromatic/rainbows/visualizations/imshow.py
+++ b/chromatic/rainbows/visualizations/imshow.py
@@ -156,6 +156,7 @@ def imshow(
         else:
             return self.fluxlike.get(k, None)
 
+    # choose between time and wavelength on the x-axis
     if xaxis.lower()[0] == "t":
         self.metadata["_imshow_extent"] = [tlower, tupper, wupper, wlower]
         xlabel, ylabel = tlabel, wlabel

--- a/chromatic/rainbows/visualizations/scatter.py
+++ b/chromatic/rainbows/visualizations/scatter.py
@@ -1,0 +1,128 @@
+from ...imports import *
+
+__all__ = ["scatter"]
+
+
+def scatter(
+    self,
+    ax=None,
+    quantity="flux",
+    xaxis="time",
+    w_unit="micron",
+    t_unit="day",
+    s=9,
+    colorbar=True,
+    mask_ok=True,
+    vmin=None,
+    vmax=None,
+    filename=None,
+    **kw,
+):
+    """
+    Paint a sparse 2D image of flux as a function of time and wavelength,
+    using `plt.scatter` to place points colored by their flux.
+
+    Parameters
+    ----------
+    ax : Axes, optional
+        The axes into which to make this plot.
+    quantity : str, optional
+        The fluxlike quantity to scatter.
+        (Must be a key of `rainbow.fluxlike`).
+    w_unit : str, Unit, optional
+        The unit for plotting wavelengths.
+    t_unit : str, Unit, optional
+        The unit for plotting times.
+    colorbar : bool, optional
+        Should we include a colorbar?
+    mask_ok : bool, optional
+        Should we hide data that are not OK?
+    color_ok : str, optional
+        The color to be used for masking data points that are not OK.
+    alpha_ok : float, optional
+        The transparency to be used for masking data points that are not OK.
+    **kw : dict, optional
+        All other keywords will be passed on to `plt.scatter`,
+        so you can have more detailed control over the plot
+        appearance. Common keyword arguments might include:
+        `[cmap, norm, interpolation, alpha, vmin, vmax]` (and more)
+        More details are available at
+        https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html
+    """
+
+    # self.speak(f'imshowing')
+    if ax is None:
+        ax = plt.subplot()
+
+    # get units
+    w_unit, t_unit = u.Unit(w_unit), u.Unit(t_unit)
+
+    # set up the x and y axes
+    w, t = np.meshgrid(self.wavelength, self.time, indexing="ij")
+    wlabel = f"{self._wave_label} ({w_unit.to_string('latex_inline')})"
+    tlabel = f"{self._time_label} ({t_unit.to_string('latex_inline')})"
+    if (self.tscale == "linear" or self.tscale == "log") and (
+        self.wscale == "linear" or self.wscale == "log"
+    ):
+        cheerfully_suggest(
+            f"""
+        Times are {self.tscale}ly spaced, and wavelengths are {self.wscale}ly spaced.
+        It's likely that `.imshow` or `.pcolormesh` are better ways to display this Rainbow.
+        """
+        )
+
+    def get_2D(k):
+        """
+        A small helper to get a 2D quantity. This is a bit of
+        a kludge to help with weird cases of duplicate keys
+        (for example where 'wavelength' might appear in both
+        `wavelike` and `fluxlike`).
+        """
+        z = self.get(k)
+        if np.shape(z) == self.shape:
+            return z
+        else:
+            return self.fluxlike.get(k, None)
+
+    z = get_2D(quantity)
+    ok = get_2D("ok")
+
+    # hide bad data if requested
+    if mask_ok:
+        w = w[ok]
+        t = t[ok]
+        z = z[ok]
+
+    # choose between time and wavelength on the x-axis
+    if xaxis.lower()[0] == "t":
+        xlabel, ylabel = tlabel, wlabel
+        x, y = t, w
+    elif xaxis.lower()[0] == "w":
+        xlabel, ylabel = wlabel, tlabel
+        x, y = w, t
+    else:
+        cheerfully_suggest(
+            "Please specify either `xaxis='time'` or `xaxis='wavelength'` for `.scatter()`"
+        )
+
+    # figure out a good shared color limits (unless already supplied)
+    vmin = vmin or np.nanpercentile(u.Quantity(z.flatten()).value * 1.0, 1)
+    vmax = vmax or np.nanpercentile(u.Quantity(z.flatten()).value * 1.0, 99)
+
+    # define some default keywords
+    scatter_kw = dict(s=s, vmin=vmin, vmax=vmax)
+    scatter_kw.update(**kw)
+    with quantity_support():
+        plt.sca(ax)
+        plt.scatter(x, y, c=z, **scatter_kw)
+        plt.ylabel(ylabel)
+        plt.xlabel(xlabel)
+        if colorbar:
+            plt.colorbar(
+                ax=ax,
+                label=u.Quantity(z).unit.to_string("latex_inline"),
+            )
+        plt.title(self.get("title"))
+
+    if filename is not None:
+        self.savefig(filename)

--- a/chromatic/tests/test_concatenate.py
+++ b/chromatic/tests/test_concatenate.py
@@ -1,0 +1,10 @@
+from .setup_tests import *
+from ..rainbows import *
+
+
+def test_concatenate_simple():
+    s = SimulatedRainbow()
+    more_wavelengths = s.concatenate_in_wavelength(s)
+    assert more_wavelengths.nwave == 2 * s.nwave
+    more_times = s.concatenate_in_time(s)
+    assert more_times.ntime == 2 * s.ntime

--- a/chromatic/tests/test_visualizations.py
+++ b/chromatic/tests/test_visualizations.py
@@ -26,6 +26,46 @@ def test_imshow():
     plt.savefig(os.path.join(test_directory, "demonstration-of-imshow-units.pdf"))
 
 
+def test_scatter():
+    uniform = (
+        SimulatedRainbow(
+            dt=20 * u.minute, dw=0.02 * u.micron, wlim=[0.9, 1.1] * u.micron
+        )
+        .inject_transit()
+        .inject_noise(signal_to_noise=1000)
+        .inject_outliers()
+        .flag_outliers()
+    )
+    random = (
+        SimulatedRainbow(
+            time=np.random.normal(0, 1, 30) * u.hour,
+            wavelength=np.random.normal(1, 0.05, 20) * u.micron,
+        )
+        .inject_transit()
+        .inject_noise(signal_to_noise=1000)
+        .inject_outliers()
+        .flag_outliers()
+    )
+
+    fi, ax = plt.subplots(2, 3, figsize=(8, 4), sharex=True, sharey=True)
+    for i, r in enumerate([uniform, random]):
+        kw = dict(xaxis="wavelength", colorbar=False)
+        r.pcolormesh(ax=ax[i, 0], **kw)
+        r.scatter(ax=ax[i, 1], **kw)
+        r.pcolormesh(ax=ax[i, 2], **kw)
+        r.scatter(ax=ax[i, 2], edgecolor="black", s=9, **kw)
+    plt.ylim(-0.1, 0.1)
+    plt.xlim(0.85, 1.15)
+    ax[0, 0].set_title("pcolormesh")
+    ax[0, 1].set_title("scatter")
+    ax[0, 2].set_title("both")
+    plt.savefig(
+        os.path.join(
+            test_directory, "demonstration-of-scatter-compared-to-pcolormesh.pdf"
+        )
+    )
+
+
 def test_imshow_quantities():
     plt.close("all")
 

--- a/chromatic/version.py
+++ b/chromatic/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.7"
+__version__ = "0.4.8"
 
 
 def version():

--- a/docs/visualizing.ipynb
+++ b/docs/visualizing.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -29,6 +30,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -50,6 +52,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -68,6 +71,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -84,6 +88,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -100,6 +105,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -118,6 +124,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -134,6 +141,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -162,6 +170,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -169,6 +178,35 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 🌈.scatter()\n",
+    "\n",
+    "Display the flux as a sparesely populated image, with each pixel representing the flux for a particular time and wavelength, using `plt.scatter` to paint fluxes only where valid wavelength and time points exist."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r.scatter()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "It accepts most of the same options as `.imshow()`."
+   ]
+  },
+  {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -187,6 +225,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -203,6 +242,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -225,6 +265,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -244,6 +285,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -262,6 +304,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -280,6 +323,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -298,6 +342,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -325,6 +370,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -334,6 +380,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -359,7 +406,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/docs/visualizing.ipynb
+++ b/docs/visualizing.ipynb
@@ -109,6 +109,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "`.imshow` is often a good way to quickly display `Rainbow` objects with wavelengths and times that are approximately uniformly spaced, either linearly or logarithmically. `.pcolormesh` and `.scatter` offer more flexibility for less uniform grids. "
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 🌈.imshow_interact()\n",
     "\n",
     "Display the flux as an image on the left, with the ability to drag and select which wavelengths you would like to appear in the light curve plot on the right."
@@ -147,7 +155,7 @@
    "source": [
     "## 🌈.pcolormesh()\n",
     "\n",
-    "Display the flux as an image, with each pixel representing the flux for a particular time and wavelength, but using `plt.pcolormesh` which allows pixels to stretch and squeeze based on the actual locations of their edges. Use `.imshow()` if you want wavelength/time bins to appear with the uniform sizes; use `.pcolormesh()` if you want to allow them to transform with the axes or non-uniform edges."
+    "Display the flux as an image, with each pixel representing the flux for a particular time and wavelength, but using `plt.pcolormesh` which allows pixels to stretch and squeeze based on the actual locations of their edges. Use `.imshow()` if you want wavelength/time bins to appear with the uniform sizes; use `.pcolormesh()` if you want to allow them to transform with the axes or non-uniform edges. It accepts most of the same options as `.imshow()`.\n"
    ]
   },
   {
@@ -174,7 +182,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It accepts most of the same options as `.imshow()`."
+    "`.pcolormesh` is often a good way to quickly display `Rainbow` objects with wavelengths and times that are smoothly varying but not necessarily exactly linearly or logarithmically spaced. `.imshow` is faster for uniform grids, and `.scatter` offer more flexibility for less uniform grids. "
    ]
   },
   {
@@ -184,7 +192,7 @@
    "source": [
     "## 🌈.scatter()\n",
     "\n",
-    "Display the flux as a sparesely populated image, with each pixel representing the flux for a particular time and wavelength, using `plt.scatter` to paint fluxes only where valid wavelength and time points exist."
+    "Display the flux as a sparesely populated image, with each pixel representing the flux for a particular time and wavelength, using `plt.scatter` to paint fluxes only where valid wavelength and time points exist. It accepts most of the same options as `.imshow()`."
    ]
   },
   {
@@ -197,12 +205,11 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "attachments": {},
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "It accepts most of the same options as `.imshow()`."
+    "`.scatter` is often a good way to quickly display `Rainbow` objects with wavelengths and times that are sparse or extremely non-uniform. `.imshow` and `.pcolormesh` will be faster and may look more professional for smooth, contiguous wavelength and time grids."
    ]
   },
   {


### PR DESCRIPTION
This draft Pull Request tries to introduce options for stitching together multiple Rainbows into one object (#224 ). For now, this introduces the "easy" case of `concatenate_in_time` for where the wavelengths exactly (or almost exactly) match and `concatenate_in_wavelength` for where the times exactly (or almost exactly) match. 