### PR TITLE
fix PHOENIX metallicity dictionary bug

### DIFF
--- a/chromatic/spectra/phoenix.py
+++ b/chromatic/spectra/phoenix.py
@@ -560,7 +560,8 @@ class PHOENIXLibrary:
                 assert np.all(self.metadata[k] == metadata[k])
             for k in ["metallicity", "filename", "chromatic-version"]:
                 self.metadata[k] = np.hstack([self.metadata[k], metadata[k]])
-            self.models.update(**models)
+            for k in models:
+                self.models[k] = models[k]
 
         except (AttributeError, AssertionError):
             self.metadata = metadata

--- a/chromatic/version.py
+++ b/chromatic/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.8"
+__version__ = "0.4.9"
 
 
 def version():


### PR DESCRIPTION
@will-waalkes was having trouble interpolating to a non-zero metallicity in `get_phoenix_photons`. It looks like there was some change in how python dictionary `.update` works in recent versions, giving an error of `TypeError: keywords must be strings` in `_load_grid`. I switched to a loop, and it seems to work.