### PR TITLE
fix numpy/imshow/units problem

### DIFF
--- a/chromatic/imports.py
+++ b/chromatic/imports.py
@@ -1,6 +1,5 @@
 import matplotlib
 
-matplotlib.rcParams["figure.dpi"] = 300
 matplotlib.rcParams["figure.constrained_layout.use"] = True
 matplotlib.rcParams["figure.facecolor"] = "white"
 matplotlib.rcParams["savefig.facecolor"] = "white"

--- a/chromatic/rainbows/actions/align_wavelengths.py
+++ b/chromatic/rainbows/actions/align_wavelengths.py
@@ -46,14 +46,14 @@ def _create_shared_wavelength_axis(
     if visualize:
         fi, ax = plt.subplots(1, 2, figsize=(8, 3), dpi=300)
         plt.sca(ax[0])
-        plt.imshow(dw_per_time, aspect="auto", vmin=0)
+        plt.imshow(remove_unit(dw_per_time), aspect="auto", vmin=0)
         plt.xlabel("Time Index")
         plt.ylabel("Wavelength Index")
         plt.title(r"$\Delta\lambda$")
         plt.colorbar(orientation="horizontal", pad=0.25)
 
         plt.sca(ax[1])
-        plt.imshow(R_per_time, aspect="auto", vmin=0)
+        plt.imshow(remove_unit(R_per_time), aspect="auto", vmin=0)
         plt.xlabel("Time Index")
         plt.ylabel("Wavelength Index")
         plt.title(r"R = $\lambda/\Delta\lambda$")

--- a/chromatic/rainbows/visualizations/colors.py
+++ b/chromatic/rainbows/visualizations/colors.py
@@ -27,7 +27,7 @@ def setup_wavelength_colors(self, cmap=None, vmin=None, vmax=None, log=None):
     """
 
     # populate the cmap object
-    self.cmap = plt.cm.get_cmap(cmap)
+    self.cmap = plt.colormaps.get_cmap(cmap)
 
     vmin = vmin
     if vmin is None:

--- a/chromatic/rainbows/visualizations/diagnostics/histogram.py
+++ b/chromatic/rainbows/visualizations/diagnostics/histogram.py
@@ -70,7 +70,7 @@ def plot_histogram(
     histkw = dict(alpha=0.5)
     histkw.update(**kw)
     plt.hist(
-        flux * scaling + offset,
+        remove_unit(flux * scaling + offset),
         color=color,
         density=True,
         orientation=orientation,

--- a/chromatic/rainbows/visualizations/imshow.py
+++ b/chromatic/rainbows/visualizations/imshow.py
@@ -18,6 +18,7 @@ def imshow(
     vmin=None,
     vmax=None,
     filename=None,
+    use_pcolormesh=True,
     **kw,
 ):
     """
@@ -45,6 +46,11 @@ def imshow(
         The color to be used for masking data points that are not OK.
     alpha_ok : float, optional
         The transparency to be used for masking data points that are not OK.
+    use_pcolormesh : bool
+        If the grid is non-uniform, should jump to using `pcolormesh` instead?
+        Leaving this at the default of True will give the best chance of
+        having real Wavelength and Time axes; setting it to False will
+        end up showing Wavelength Index or Time Index instead (if non-uniform).
     **kw : dict, optional
         All other keywords will be passed on to `plt.imshow`,
         so you can have more detailed control over the plot
@@ -72,6 +78,24 @@ def imshow(
     except AttributeError:
         wmin, wmax = None, None
 
+    # define pcolormesh inputs, in case we need to use them below
+    if use_pcolormesh:
+        pcolormesh_inputs = dict(
+            ax=ax,
+            quantity=quantity,
+            xaxis=xaxis,
+            w_unit=w_unit,
+            t_unit=t_unit,
+            colorbar=colorbar,
+            mask_ok=mask_ok,
+            color_ok=color_ok,
+            alpha_ok=alpha_ok,
+            vmin=vmin,
+            vmax=vmax,
+            filename=filename,
+            **kw,
+        )
+
     if (self.wscale == "linear") and (wmin is not None) and (wmax is not None):
         wlower, wupper = wmin, wmax
         wlabel = f"{self._wave_label} ({w_unit.to_string('latex_inline')})"
@@ -81,6 +105,9 @@ def imshow(
             r"log$_{10}$" + f"[{self._wave_label}/({w_unit.to_string('latex_inline')})]"
         )
     else:
+        if use_pcolormesh:
+            self.pcolormesh(**pcolormesh_inputs)
+            return
         message = f"""
         The wavelength scale for this rainbow is '{self.wscale}',
         and there are {self.nwave} wavelength centers and
@@ -120,6 +147,9 @@ def imshow(
             r"log$_{10}$" + f"[{self._time_label}/({t_unit.to_string('latex_inline')})]"
         )
     else:
+        if use_pcolormesh:
+            self.pcolormesh(**pcolormesh_inputs)
+            return
         message = f"""
         The time scale for this rainbow is '{self.tscale}',
         and there are {self.ntime} time centers and
@@ -173,8 +203,8 @@ def imshow(
         )
 
     # figure out a good shared color limits (unless already supplied)
-    vmin = vmin or np.nanpercentile(u.Quantity(z.flatten()).value * 1.0, 1)
-    vmax = vmax or np.nanpercentile(u.Quantity(z.flatten()).value * 1.0, 99)
+    vmin = vmin or np.nanpercentile(remove_unit(z).flatten() * 1.0, 1)
+    vmax = vmax or np.nanpercentile(remove_unit(z).flatten() * 1.0, 99)
 
     # define some default keywords
     imshow_kw = dict(interpolation="nearest", vmin=vmin, vmax=vmax)
@@ -197,14 +227,14 @@ def imshow(
                 vmax=1,
             )
             plt.imshow(
-                ok,
+                remove_unit(ok),
                 extent=self.metadata["_imshow_extent"],
                 aspect=aspect,
                 origin="upper",
                 **okimshow_kw,
             )
         plt.imshow(
-            z,
+            remove_unit(z),
             extent=self.metadata["_imshow_extent"],
             aspect=aspect,
             origin="upper",

--- a/chromatic/rainbows/visualizations/pcolormesh.py
+++ b/chromatic/rainbows/visualizations/pcolormesh.py
@@ -106,8 +106,8 @@ def pcolormesh(
         )
 
     # figure out a good shared color limits (unless already supplied)
-    vmin = vmin or np.nanpercentile(u.Quantity(z.flatten()).value, 1)
-    vmax = vmax or np.nanpercentile(u.Quantity(z.flatten()).value, 99)
+    vmin = vmin or np.nanpercentile(remove_unit(z).flatten(), 1)
+    vmax = vmax or np.nanpercentile(remove_unit(z).flatten(), 99)
 
     # define some default keywords
     pcolormesh_kw = dict(shading="flat", vmin=vmin, vmax=vmax)
@@ -128,15 +128,15 @@ def pcolormesh(
                 vmax=1,
             )
             plt.pcolormesh(
-                x,
-                y,
-                ok,
+                remove_unit(x),
+                remove_unit(y),
+                remove_unit(ok),
                 **okpcolormesh_kw,
             )
         plt.pcolormesh(
-            x,
-            y,
-            z,
+            remove_unit(x),
+            remove_unit(y),
+            remove_unit(z),
             **pcolormesh_kw,
         )
         plt.ylabel(ylabel)

--- a/chromatic/tests/test_align_wavelengths.py
+++ b/chromatic/tests/test_align_wavelengths.py
@@ -11,7 +11,6 @@ def create_simulation_with_wobbly_wavelengths(
     dt=30 * u.minute,
     **kw
 ):
-
     # set up a function to create a fake absorption line spectrum
     N = 10
     centers = (
@@ -63,14 +62,14 @@ def test_align_wavelengths(fractional_shift=0.002, dw=0.001 * u.micron, **kw):
     fi, ax = plt.subplots(2, 2, dpi=300, figsize=(8, 6), constrained_layout=True)
     for i, x in enumerate([r, a]):
         plt.sca(ax[0, i])
-        plt.imshow(x.flux, aspect="auto", cmap="gray")
+        plt.imshow(remove_unit(x.flux), aspect="auto", cmap="gray")
         plt.title(["original", "aligned"][i] + " flux")
         plt.xlabel("time index")
         plt.ylabel("wavelength index")
         plt.colorbar()
 
         plt.sca(ax[1, i])
-        plt.imshow(x.fluxlike["wavelength_2d"], aspect="auto")
+        plt.imshow(remove_unit(x.fluxlike["wavelength_2d"]), aspect="auto")
         plt.title(["original", "aligned"][i] + " wavelength")
         plt.xlabel("time index")
         plt.ylabel("wavelength index")

--- a/chromatic/tests/test_visualizations.py
+++ b/chromatic/tests/test_visualizations.py
@@ -203,12 +203,12 @@ def test_imshow_one_wavelength():
     with pytest.warns(match="hard to imshow "):
 
         s = SimulatedRainbow(wavelength=[1] * u.micron).inject_noise()
-        ax = s.imshow()
+        ax = s.imshow(use_pcolormesh=False)
         assert "Wavelength Index" in ax.get_ylabel()
 
         s = SimulatedRainbow().inject_noise()
         b = s.bin(nwavelengths=s.nwave)
-        ax = b.imshow()
+        ax = b.imshow(use_pcolormesh=False)
         assert "Wavelength (" in ax.get_ylabel()
         ylim = ax.get_ylim()
     plt.savefig(
@@ -237,9 +237,11 @@ def test_imshow_randomized_axes():
 
         fi, ax = plt.subplots(1, 3, figsize=(10, 3), constrained_layout=True)
         kw = dict(vmin=0.98, vmax=1.02)
-        s.imshow(ax=ax[0], **kw)
-        s.get_average_spectrum_as_rainbow().imshow(ax=ax[1], **kw)
-        s.get_average_lightcurve_as_rainbow().imshow(ax=ax[2], **kw)
+        s.imshow(ax=ax[0], use_pcolormesh=False, **kw)
+        s.get_average_spectrum_as_rainbow().imshow(ax=ax[1], use_pcolormesh=False, **kw)
+        s.get_average_lightcurve_as_rainbow().imshow(
+            ax=ax[2], use_pcolormesh=False, **kw
+        )
         for i in [0, 2]:
             assert "Time Index" in ax[i].get_xlabel()
         for i in [0, 1]:

--- a/chromatic/version.py
+++ b/chromatic/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.9"
+__version__ = "0.4.10"
 
 
 def version():


### PR DESCRIPTION
I'm not sure why, but some problem emerged with some new version of either `numpy`, `matplotlib`, or `astropy` where attempting to `imshow` quantities with astropy units would through unit conversion errors. This PR (I think!) fixes the problem by stripping units before imshowing them with `remove_units`. 

It also modifies `rainbow.imshow` to default to `.pcolormesh` for non-uniform grids, unless being told not to with `use_pcolormesh=False`.