### PR TITLE
Update stellar model libraries for `chromatic`.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 22.6.0
+  rev: 24.4.2
   hooks:
   - id: black
 - repo: https://github.com/psf/black
-  rev: 22.6.0
+  rev: 24.4.2
   hooks:
     - id: black-jupyter
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v4.6.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer

--- a/chromatic/imports.py
+++ b/chromatic/imports.py
@@ -90,6 +90,7 @@ def download_file_with_warning(*args, **kwargs):
         """
         )
     kwargs["show_progress"] = True
+    kwargs["allow_insecure"] = True
     return download_file(*args, **kwargs)
 
 

--- a/chromatic/rainbows/actions/inject_systematics.py
+++ b/chromatic/rainbows/actions/inject_systematics.py
@@ -158,7 +158,6 @@ def inject_systematics(
     timelike=["x", "y", "time"],
     fluxlike=["background"],
 ):
-
     """
     Inject some (very cartoony) instrumental systematics.
 

--- a/chromatic/rainbows/actions/inject_transit.py
+++ b/chromatic/rainbows/actions/inject_transit.py
@@ -327,7 +327,6 @@ def inject_transit(
     method="exoplanet",
     **transit_parameters,
 ):
-
     """
     Simulate a wavelength-dependent planetary transit.
 

--- a/chromatic/rainbows/helpers/history.py
+++ b/chromatic/rainbows/helpers/history.py
@@ -1,6 +1,7 @@
 """
 Add ability for Rainbow to keep track of their own history.
 """
+
 from ...imports import *
 
 __all__ = [

--- a/chromatic/rainbows/readers/atoca.py
+++ b/chromatic/rainbows/readers/atoca.py
@@ -2,6 +2,7 @@
 Define a reader for NIRISS/SOSS extract1d files produced using the ATOCA
 algorithm.
 """
+
 from ...imports import *
 
 __all__ = ["from_atoca"]

--- a/chromatic/rainbows/readers/coulombe.py
+++ b/chromatic/rainbows/readers/coulombe.py
@@ -1,6 +1,7 @@
 """
 Define a reader for STScI pipeline x1dints.fits files.
 """
+
 from ...imports import *
 
 __all__ = ["from_coulombe"]

--- a/chromatic/rainbows/readers/x1dints.py
+++ b/chromatic/rainbows/readers/x1dints.py
@@ -1,6 +1,7 @@
 """
 Define a reader for STScI pipeline x1dints.fits files.
 """
+
 from ...imports import *
 
 __all__ = ["from_x1dints"]

--- a/chromatic/rainbows/readers/x1dints_kludge.py
+++ b/chromatic/rainbows/readers/x1dints_kludge.py
@@ -1,6 +1,7 @@
 """
 Define a reader for STScI pipeline x1dints.fits files.
 """
+
 from ...imports import *
 
 __all__ = ["from_x1dints_kludge"]

--- a/chromatic/rainbows/writers/text.py
+++ b/chromatic/rainbows/writers/text.py
@@ -2,7 +2,6 @@
 Define a writer for chromatic .rainbow.npy files.
 """
 
-
 # import the general list of packages
 from ...imports import *
 

--- a/chromatic/spectra/phoenix.py
+++ b/chromatic/spectra/phoenix.py
@@ -169,10 +169,10 @@ class PHOENIXLibrary:
         metallicity_string = self._stringify_metallicity(metallicity)
         self._raw_directory = f"PHOENIX-ACES-AGSS-COND-2011/Z{metallicity_string}"
         self._raw_directory_url = "/".join([self._raw_base_url, self._raw_directory])
-        self._raw_local_paths[
-            f"index-Z={metallicity_string}"
-        ] = download_file_with_warning(
-            self._raw_directory_url, pkgname=self._cache_label, cache=cache
+        self._raw_local_paths[f"index-Z={metallicity_string}"] = (
+            download_file_with_warning(
+                self._raw_directory_url, pkgname=self._cache_label, cache=cache
+            )
         )
         cheerfully_suggest(
             f"""


### PR DESCRIPTION
This draft starts to improve the stellar spectrum models. 
- The first tiny fix is a patch for downloads not working with the old Husser et al. (2013) PHOENIX models that were pre-made and stored at https://casa.colorado.edu/~bertathompson/chromatic/. This is probably (?) a problem with the CASA server, but as a slightly risky fix we added `allow_insecure=True` to the `astropy` downloader. 