### PR TITLE
fix x1dints reader to better handle having only some segments available

### DIFF
--- a/chromatic/version.py
+++ b/chromatic/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.11"
+__version__ = "0.4.12"
 
 
 def version():


### PR DESCRIPTION
In addressing #242 , this updates the `from_x1dints` reader to do a better job loading x1dints files that have been split into multiple segments, even if some segments are missing. In *most* cases, it *should* offer a warning if it can detect that some segment files are missing.