### PR TITLE
Calculate `'effective_wavelength'` when binning in wavelength. 

### DIFF
--- a/chromatic/rainbows/actions/binning.py
+++ b/chromatic/rainbows/actions/binning.py
@@ -593,6 +593,14 @@ def bin_in_wavelength(
     new.wavelike["unbinned_wavelengths_per_binned_wavelength"] = binned[
         "N_unbinned/N_binned"
     ]
+    uncertainty_per_wavelength = self.get_expected_uncertainty()
+    uncertainty_weighted_binned = binning_function(
+        x=self.wavelike["wavelength"],
+        y=self.wavelike["wavelength"],
+        unc=uncertainty_per_wavelength,
+        **binkw,
+    )
+    new.wavelike["effective_wavelength"] = uncertainty_weighted_binned["y"]
 
     # bin the flux-like variables
     # TODO (add more careful treatment of uncertainty + DQ)

--- a/chromatic/tests/test_binning.py
+++ b/chromatic/tests/test_binning.py
@@ -304,3 +304,41 @@ def test_uncertainty_weighting_during_binning():
 def test_warning_about_binning_before_normalizing():
     with pytest.warns(match="Please consider normalizing"):
         SimulatedRainbow().inject_spectrum().inject_noise().bin(R=10)
+
+
+def test_binning_effective_wavelength():
+    N = 101
+    blank = SimulatedRainbow(wavelength=np.linspace(5, 10, N) * u.micron)
+    with_slope = blank * (1 + np.linspace(-1, 1, N) * 1e-1)
+    noisy = with_slope.inject_noise(signal_to_noise=np.logspace(2, 5, N))
+    binned = noisy.bin(dw=1 * u.micron)
+
+    i = 0
+    ekw = dict(marker="o", linewidth=0, elinewidth=1)
+    # plt.plot(s.wavelength, s.model[:,i])
+    plt.errorbar(
+        noisy.wavelength,
+        noisy.flux[:, i],
+        noisy.uncertainty[:, i],
+        color="gray",
+        alpha=0.25,
+        **ekw,
+    )
+    plt.errorbar(
+        binned.wavelength,
+        binned.flux[:, i],
+        binned.uncertainty[:, i],
+        color="red",
+        label="unweighted",
+        **ekw,
+    )
+    plt.errorbar(
+        binned.effective_wavelength,
+        binned.flux[:, i],
+        binned.uncertainty[:, i],
+        color="black",
+        label="weighted",
+        **ekw,
+    )
+    plt.plot(noisy.wavelength, noisy.model[:, 0])
+    plt.legend()


### PR DESCRIPTION
To address #245 , this calculates an inverse-variance weighted average wavelength value for each wavelength bin, whenever binning a `Rainbow` in wavelength. It can be retrieved either through the `wavelike` dictionary or as an attribute, like this:

```python
binned = rainbow.bin(dw=1*u.micron)
binned.wavelike['effective_wavelength'], binned.effective_wavelength
```

This effective wavelength is a better represented average to use when plotting comparisons to models in wavelength space, as shown in the text example below.

```python
def test_binning_effective_wavelength():
    N = 101
    blank = SimulatedRainbow(wavelength=np.linspace(5, 10, N)*u.micron)
    with_slope = blank*(1 + np.linspace(-1, 1, N)*1e-1)
    noisy = with_slope.inject_noise(signal_to_noise=np.logspace(2, 5, N))
    binned = noisy.bin(dw=1*u.micron)

    i = 0
    ekw = dict(marker='o', linewidth=0, elinewidth=1)
    #plt.plot(s.wavelength, s.model[:,i])
    plt.errorbar(noisy.wavelength, noisy.flux[:,i], noisy.uncertainty[:,i], color='gray', alpha=0.25, **ekw)
    plt.errorbar(binned.wavelength, binned.flux[:,i], binned.uncertainty[:,i], color='red', label='unweighted', **ekw)
    plt.errorbar(binned.effective_wavelength, binned.flux[:,i], binned.uncertainty[:,i], color='black', label='weighted', **ekw)
    plt.plot(noisy.wavelength, noisy.model[:,0]);
    plt.legend()
```

![image](https://github.com/user-attachments/assets/de9d4e44-8f0e-4fdd-981b-1dd37a16f8d4)
