### PR TITLE
fix x1dints reader to better guess the number of orders in NIRISS data

### DIFF
--- a/chromatic/rainbows/readers/x1dints.py
+++ b/chromatic/rainbows/readers/x1dints.py
@@ -236,11 +236,17 @@ def from_x1dints(rainbow, filepath, order=None, **kw):
                 # store the entire primary header in metadata
                 rainbow.metadata["header"] = hdu["PRIMARY"].header
 
+                def determine_number_of_orders(hdu):
+                    if hdu["PRIMARY"].header["INSTRUME"] == "NIRISS":
+                        n_orders = len(
+                            np.unique([h.header["SPORDER"] for h in hdu[3:-1]])
+                        )
+                    else:
+                        n_orders = 1
+                    return n_orders
+
                 # figure out the number of orders allowed for this dataset
-                if hdu["PRIMARY"].header["INSTRUME"] == "NIRISS":
-                    n_orders = 3
-                else:
-                    n_orders = 1
+                n_orders = determine_number_of_orders(hdu)
 
                 if order is None:
                     order = 1

--- a/chromatic/version.py
+++ b/chromatic/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.12"
+__version__ = "0.4.13"
 
 
 def version():


### PR DESCRIPTION
This pull request fixes a bug in the `x1dints` reader, where it always assumes that NIRISS data have three spectral orders. Now, it determine the number of orders from the `SPORDER` keyword header in the the `EXTRACT1D` extensions of the FITS file. 