### PR TITLE
Add MAST downloader + fix broken quickstart

### DIFF
--- a/chromatic/__init__.py
+++ b/chromatic/__init__.py
@@ -3,3 +3,4 @@ from .rainbows import *
 from .imports import *
 from .resampling import *
 from .spectra import *
+from .archives import *

--- a/chromatic/archives/__init__.py
+++ b/chromatic/archives/__init__.py
@@ -1,0 +1,1 @@
+from .mast import *

--- a/chromatic/archives/mast.py
+++ b/chromatic/archives/mast.py
@@ -1,0 +1,86 @@
+from astroquery.mast import Observations
+
+__all__ = ["download_from_mast"]
+
+
+def download_from_mast(
+    proposal_id="2734",
+    target_name="WASP-96",
+    obs_collection="JWST",
+    instrument_name="*",
+    productSubGroupDescription="X1DINTS",
+    calib_level=2,
+):
+    """
+    Download (JWST) data products from MAST.
+
+    Given a set of search criteria, find the data products
+    and download them locally. This has been tested only
+    minimally for retrieving X1DINTS files for JWST
+    time-series observations for quick look analyses.
+    It should hopefully work more broadly?
+
+    If the data Exclusive Access data that are still
+    in their proprietary period, you will need to
+    login with `Observations.login()` to authenticate
+    your connection to the MAST archive.
+
+    For more details on programmatically accessing
+    data from MAST, it may be useful to explore the
+    example notebooks available at:
+
+    https://spacetelescope.github.io/mast_notebooks/
+
+    Parameters
+    ----------
+
+    **kw : dict
+        Remaining keywords will be passed to `Observations.query_critera`.
+        Available keywords for this initial search likely include:
+        ['intentType', 'obs_collection', 'provenance_name',
+       'instrument_name', 'project', 'filters', 'wavelength_region',
+       'target_name', 'target_classification', 'obs_id', 's_ra', 's_dec',
+       'proposal_id', 'proposal_pi', 'obs_title', 'dataproduct_type',
+       'calib_level', 't_min', 't_max', 't_obs_release', 't_exptime',
+       'em_min', 'em_max', 'objID', 's_region', 'jpegURL', 'distance',
+       'obsid', 'dataRights', 'mtFlag', 'srcDen', 'dataURL',
+       'proposal_type', 'sequence_number']
+
+    Returns
+    -------
+    downloaded : astropy.table.Table
+        A table summarizing what was downloaded. The columns
+        of this table will likely include:
+        ['Local Path', 'Status', 'Message', 'URL']
+        where 'Local Path' indicates to where the file
+        was downloaded (relative to the local path),
+        and 'Status' indicates whether the download
+        was successful.
+
+    """
+
+    # get a table of all observations matching the search criteria
+    obs_table = Observations.query_criteria(
+        obs_collection=obs_collection,
+        proposal_id=proposal_id,
+        instrument_name=instrument_name,
+        target_name=target_name,
+    )
+
+    # get a table of the list of products associated with those observations
+    products = Observations.get_product_list(obs_table["obsid"])
+
+    # filter those products down to just what's requested
+    if isinstance(calib_level, int):
+        calib_level = [calib_level]
+    filtered_products = Observations.filter_products(
+        products,
+        productSubGroupDescription=productSubGroupDescription,
+        calib_level=calib_level,
+    )
+
+    # download the filtered products
+    downloaded = Observations.download_products(filtered_products)
+
+    # return table summarizing the downloaded files
+    return downloaded

--- a/chromatic/imports.py
+++ b/chromatic/imports.py
@@ -43,7 +43,7 @@ warnings.formatwarning = custom_formatwarning
 """
 # astropy
 from astropy.io import ascii, fits
-from astropy.table import Table, QTable
+from astropy.table import Table, QTable, Column
 from astropy.time import Time
 from astropy.stats import sigma_clip, median_absolute_deviation, mad_std
 
@@ -99,6 +99,8 @@ def expand_filenames(filepath):
     """
     if type(filepath) == list:
         filenames = filepath
+    elif type(filepath) == Column:
+        filenames = list(filepath)
     elif "*" in filepath:
         filenames = np.sort(glob.glob(filepath))
     else:

--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -223,7 +223,7 @@ class Rainbow:
             if metadata is not None:
                 self.metadata.update(**metadata)
         # then try to initialize from a file
-        elif isinstance(filepath, str) or isinstance(filepath, list):
+        elif isinstance(filepath, (str, list, Column)):
             self._initialize_from_file(filepath=filepath, format=format, **kw)
 
         # finally, tidy up by guessing the scales

--- a/chromatic/tests/test_archives.py
+++ b/chromatic/tests/test_archives.py
@@ -1,0 +1,7 @@
+from ..archives import *
+from .setup_tests import *
+
+
+def test_download_from_mast():
+    d = download_from_mast()
+    assert d[0]["Status"] == "COMPLETE"

--- a/chromatic/version.py
+++ b/chromatic/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.13"
+__version__ = "0.4.14"
 
 
 def version():

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -12,12 +12,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "7745c111",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from chromatic import read_rainbow, version\n",
+    "from chromatic import download_from_mast, read_rainbow, version\n",
     "from astroquery.mast import Observations\n",
     "import astropy.units as u"
    ]
@@ -38,7 +38,7 @@
    "metadata": {},
    "source": [
     "## 💾 Download\n",
-    "Let's download the [JWST Early Release Observation of HAT-P-18b](https://www.stsci.edu/jwst/science-execution/approved-programs/webb-first-image-observations), one of first exoplanet transit datasets to be gathered by the telescope. We'll get the default pipeline `x1dints` (Stage 3) outputs; there are lots of reasons why we shouldn't use these particular pipeline files for science, but they're useful for a quick initial look."
+    "Let's download the [JWST Early Release Observation of HAT-P-18b](https://www.stsci.edu/jwst/science-execution/approved-programs/webb-first-image-observations), one of first exoplanet transit datasets to be gathered by the telescope. We'll get the default pipeline `x1dints` (Stage 2) outputs; there are lots of reasons why we shouldn't use these particular pipeline files for science, but they're useful for a quick initial look."
    ]
   },
   {
@@ -48,9 +48,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Observations.download_file(\n",
-    "    f\"mast:JWST/product/jw02734-o001_t001_niriss_clear-gr700xd-substrip256_x1dints.fits\"\n",
-    ");"
+    "downloaded = download_from_mast(\n",
+    "    proposal_id=\"2734\", instrument_name=\"NIRISS/SOSS\", target_name=\"WASP-96\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de9c563c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "downloaded"
    ]
   },
   {
@@ -69,9 +79,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rainbow = read_rainbow(\n",
-    "    \"jw02734-o001_t001_niriss_clear-gr700xd-substrip256_x1dints.fits\"\n",
-    ")"
+    "filenames = downloaded[\"Local Path\"]\n",
+    "rainbow = read_rainbow(filenames)"
    ]
   },
   {
@@ -140,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "48c38d8c",
    "metadata": {},
    "outputs": [],
@@ -176,7 +185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "822e3733",
    "metadata": {},
    "outputs": [],
@@ -273,7 +282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "70a1a115",
    "metadata": {},
    "outputs": [],
@@ -312,7 +321,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "2024",
    "language": "python",
    "name": "python3"
   },
@@ -326,7 +335,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
#254 points out the quickstart documentation was broken because of a filepath error. To make the downloading more robust + intuitive, this pull request...
- introduces `download_from_mast` to make it easier to download basic JWST files from MAST 
- replaces a fragile direct link download with `download_from_mast` in `quickstart.ipynb` 
- updates version to `0.4.14`