### PR TITLE
Initial commits for creating a to_spectra() function for Rainbow objects

### DIFF
--- a/chromatic/imports.py
+++ b/chromatic/imports.py
@@ -51,6 +51,7 @@ from astropy.io import ascii, fits
 from astropy.table import Table, QTable, Column
 from astropy.time import Time
 from astropy.stats import sigma_clip, median_absolute_deviation, mad_std
+from astropy.nddata import StdDevUncertainty
 
 # import astropy.units as u
 import astropy.constants as con
@@ -63,6 +64,9 @@ from scipy.interpolate import interp1d
 
 # For converting Rainbows to pandas dataframe
 import pandas as pd
+
+# For converting Rainbows to specutils Spectrum
+from specutils import Spectrum 
 
 from .tools.custom_units import *
 

--- a/chromatic/rainbows/converters/for_altair.py
+++ b/chromatic/rainbows/converters/for_altair.py
@@ -1,6 +1,6 @@
 from ...imports import *
 
-__all__ = ["to_nparray", "to_df"]
+__all__ = ["to_nparray", "to_df", "to_spectra"]
 
 
 def to_nparray(self, t_unit="d", w_unit="micron"):
@@ -94,3 +94,69 @@ def to_df(self, t_unit="d", w_unit="micron"):
     # convert to pandas dataframe
     df = pd.DataFrame(rainbow_dict)
     return df
+
+
+def to_spectra(self, f_unit='erg', t_unit='d', w_unit='micron'):
+    """Convert Rainbow object to an array of spectra (one per time)
+
+    Parameters
+    ----------
+        self : Rainbow object
+            chromatic Rainbow object to convert into specutils.Spectrum objects
+        f_unit : astropy.unit
+            (optional, default='erg')
+            a flux unit to instantiate the Spectrum objects
+        t_unit : astropy.unit
+            (optional, default='d')
+            The time units to use (seconds, minutes, hours, days etc.)
+        w_unit : astropy.unit
+            (optional, default='micron')
+            The wavelength units to use
+    Returns
+    ----------
+        spectra: np.array of specutils.Spectrum objects
+            A list of Spectrum objects, one for each time step
+    """
+    # Determine how many discrete `times` are contained in the Rainbow
+    times = self.timelike['time']
+    try:
+        # nice bit of code copied from .imshow(), thanks Zach!
+        # Change time into the units requested by the user
+        t_unit = u.Unit(t_unit)
+    except:
+        cheerfully_suggest("Unrecognised Time Format! Returning day by default")
+        t_unit = u.Unit("d")
+    halfday = (0.5*u.day).to(t_unit)
+    times = times.to(t_unit)
+
+    try:
+        # Change wavelength into the units requested by the user
+        w_unit = u.Unit(w_unit)
+    except:
+        cheerfully_suggest(
+            "Unrecognised Wavelength Format! Returning micron by default"
+        )
+        w_unit = u.Unit("micron")
+
+    try:
+        # Change flux into the units requested by the user
+        f_unit = u.Unit(f_unit)
+    except:
+        cheerfully_suggest(
+            "Unrecognised Flux Format! Returning erg by default"
+        )
+        f_unit = u.Unit("erg")
+   
+    spectra = []
+    for time in times:
+        _temp = self.trim_times(t_min = time-halfday, t_max = time+halfday)
+        _wl = _temp.wavelength.to(w_unit).value
+        _flux = np.concat([_temp.fluxlike['flux']])
+        _err = StdDevUncertainty(np.concat([_temp.fluxlike['uncertainty']]))
+        good_values = np.concat(np.isfinite(_flux))
+        true_spec = Spectrum(flux = _flux[good_values]*f_unit, \
+                             spectral_axis = _wl[good_values]*w_unit, \
+                             uncertainty=_err[good_values], \
+                             meta=_temp.timelike)
+        spectra.append(true_spec)
+    return np.array(spectra)

--- a/chromatic/rainbows/rainbow.py
+++ b/chromatic/rainbows/rainbow.py
@@ -1063,6 +1063,7 @@ class Rainbow:
     from .converters import (
         to_nparray,
         to_df,
+        to_spectra,
     )
 
     from .helpers import (

--- a/chromatic/tests/test_conversions.py
+++ b/chromatic/tests/test_conversions.py
@@ -64,3 +64,29 @@ def test_to_nparray():
     # test if the minutes format works
     rflux, rfluxu, rtime, rwavel = r.to_nparray(t_unit="s")
     assert np.all(np.isclose(rtime, r.time.to_value("h") * 3600, **closekw))
+
+def test_to_spectra():
+    times = np.arange(1, 30) * u.day
+    r = SimulatedRainbow(dt=1 * u.minute, R=50, time=times).inject_noise(signal_to_noise=10)
+
+    r_specs = r.to_spectra()
+
+    # ensure we have a spectrum for each discrete time
+    assert len(r_specs) == len(r.time)
+
+    # ensure the length of each quanity in each spectrum is the same as the original rainbow WLs
+    for index, obj in enumerate(r_specs):
+        assert len(obj.spectral_axis) == len(r.wavelength)
+        assert len(obj.flux) == len(r.flux[:, index])
+        assert len(obj.uncertainty) == np.shape( r.uncertainty[:, index])[0]
+
+
+    # check the values in the spectrums match the rainbow
+    for index, obj in enumerate(r_specs):
+        assert np.concat(obj.flux.value) == r.flux[:, index]
+        assert np.concat(obj.uncertainty.value) == r.uncertainty[:, index]
+
+    # test the wlformat parameter
+    for w_unit, phys in zip(["micron", "nm", "Angstrom"], [u.micron, u.nm, u.Angstrom]):
+        r_spec = r.to_spectra(w_unit=w_unit)
+        assert r_spec[0].spectral_axis.unit == phys

--- a/chromatic/tests/test_conversions.py
+++ b/chromatic/tests/test_conversions.py
@@ -90,3 +90,13 @@ def test_to_spectra():
     for w_unit, phys in zip(["micron", "nm", "Angstrom"], [u.micron, u.nm, u.Angstrom]):
         r_spec = r.to_spectra(w_unit=w_unit)
         assert r_spec[0].spectral_axis.unit == phys
+
+    # test the time format parameter
+    for t_unit, phys in zip(["h", "hour", "day", "minute", "second", "s"], [u.hour, u.hour, u.day, u.minute, u.second, u.second]):
+        r_spec = r.to_spectra(t_unit=t_unit)
+        assert r_spec[0].time.unit == phys
+
+    # test the flux format parameter
+    for f_unit, phys in zip(["W/m2/um", "erg/s/cm2/AA"], [u.Unit("W/m2/um"), u.Unit("erg/s/cm2/AA")]):
+        r_spec = r.to_spectra(f_unit=f_unit)
+        assert r_spec[0].flux.unit == phys

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ setup(
         "h5netcdf",
         "exoplanet-core",
         "astroquery",
+        "specutils"
     ],
     # what version of Python is required?
     python_requires=">=3.7",  # f-strings are introduced in 3.6!


### PR DESCRIPTION
I've added the function `to_spectra()` to the `chromatic/rainbow/for_altair` converter. This allows turning a Rainbow object  (presumably one that has already been binned per-night) with multiple discrete observations split by night. I have written some tests (though I think I'll need to add one or two more to it) but wanted to initiate the pull request to start getting others eyes on it.  This is also in relation to https://github.com/zkbt/chromatic/issues/263 which mentions the need for a function like this